### PR TITLE
Fixed remote command http response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.xcuserstate
 *.xcbkptlist
 tealium/tealium_debug/Swifter
+*.xcuserdatad*

--- a/samples/iOS_SegueCatalog+tealium/SegueCatalog.xcodeproj/project.pbxproj
+++ b/samples/iOS_SegueCatalog+tealium/SegueCatalog.xcodeproj/project.pbxproj
@@ -36,8 +36,8 @@
 		713F62841E51860000550020 /* TealiumLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713F627E1E5184D600550020 /* TealiumLifecycle.swift */; };
 		713F62851E51860000550020 /* TealiumLifecycleModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713F627F1E5184D600550020 /* TealiumLifecycleModule.swift */; };
 		713F62861E51860000550020 /* TealiumLifecyclePersistentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 713F62801E5184D600550020 /* TealiumLifecyclePersistentData.swift */; };
-		714D31FB1E7856AA0073C2ED /* TealiumRemoteCommandReponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714D31FA1E7856AA0073C2ED /* TealiumRemoteCommandReponse.swift */; };
-		714D31FC1E7856EB0073C2ED /* TealiumRemoteCommandReponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714D31FA1E7856AA0073C2ED /* TealiumRemoteCommandReponse.swift */; };
+		714D31FB1E7856AA0073C2ED /* TealiumRemoteCommandResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714D31FA1E7856AA0073C2ED /* TealiumRemoteCommandResponse.swift */; };
+		714D31FC1E7856EB0073C2ED /* TealiumRemoteCommandResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714D31FA1E7856AA0073C2ED /* TealiumRemoteCommandResponse.swift */; };
 		714D31FE1E785CCA0073C2ED /* TealiumRemoteCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714D31FD1E785CCA0073C2ED /* TealiumRemoteCommand.swift */; };
 		714D31FF1E785D040073C2ED /* TealiumRemoteCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714D31FD1E785CCA0073C2ED /* TealiumRemoteCommand.swift */; };
 		714D32021E7885F60073C2ED /* TealiumUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714D32011E7885F60073C2ED /* TealiumUtils.swift */; };
@@ -143,7 +143,7 @@
 		713F627F1E5184D600550020 /* TealiumLifecycleModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TealiumLifecycleModule.swift; sourceTree = "<group>"; };
 		713F62801E5184D600550020 /* TealiumLifecyclePersistentData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TealiumLifecyclePersistentData.swift; sourceTree = "<group>"; };
 		7142404D1E0B066A007D6651 /* TealiumAutotrackingModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TealiumAutotrackingModule.swift; sourceTree = "<group>"; };
-		714D31FA1E7856AA0073C2ED /* TealiumRemoteCommandReponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TealiumRemoteCommandReponse.swift; sourceTree = "<group>"; };
+		714D31FA1E7856AA0073C2ED /* TealiumRemoteCommandResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TealiumRemoteCommandResponse.swift; sourceTree = "<group>"; };
 		714D31FD1E785CCA0073C2ED /* TealiumRemoteCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TealiumRemoteCommand.swift; sourceTree = "<group>"; };
 		714D32011E7885F60073C2ED /* TealiumUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TealiumUtils.swift; sourceTree = "<group>"; };
 		7153ADEF1E7716580020CDA5 /* TealiumDatasourceModule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TealiumDatasourceModule.swift; sourceTree = "<group>"; };
@@ -343,7 +343,7 @@
 			isa = PBXGroup;
 			children = (
 				714D31FD1E785CCA0073C2ED /* TealiumRemoteCommand.swift */,
-				714D31FA1E7856AA0073C2ED /* TealiumRemoteCommandReponse.swift */,
+				714D31FA1E7856AA0073C2ED /* TealiumRemoteCommandResponse.swift */,
 				7153AE151E773B600020CDA5 /* TealiumRemoteCommands.swift */,
 				7153AE0C1E773AD40020CDA5 /* TealiumRemoteCommandsModule.swift */,
 				7153AE101E773B520020CDA5 /* TealiumRemoteHTTPCommand.swift */,
@@ -582,7 +582,7 @@
 				71EBA73E1DDCD1FF00813470 /* TealiumCollectConstants.swift in Sources */,
 				710DE8D01DD6803D00473D35 /* TealiumCollect.swift in Sources */,
 				7153AE0D1E773AD40020CDA5 /* TealiumRemoteCommandsModule.swift in Sources */,
-				714D31FB1E7856AA0073C2ED /* TealiumRemoteCommandReponse.swift in Sources */,
+				714D31FB1E7856AA0073C2ED /* TealiumRemoteCommandResponse.swift in Sources */,
 				710DE8D21DD6803D00473D35 /* Tealium.swift in Sources */,
 				714D31FE1E785CCA0073C2ED /* TealiumRemoteCommand.swift in Sources */,
 				71358D681E54D15D00BFD0B3 /* TealiumLifecycleSession.swift in Sources */,
@@ -642,7 +642,7 @@
 				7153AE041E771A500020CDA5 /* TealiumDatasourceModule.swift in Sources */,
 				717897B01E3175E800CB5B5A /* Tealium.swift in Sources */,
 				71358D691E54D15D00BFD0B3 /* TealiumLifecycleSession.swift in Sources */,
-				714D31FC1E7856EB0073C2ED /* TealiumRemoteCommandReponse.swift in Sources */,
+				714D31FC1E7856EB0073C2ED /* TealiumRemoteCommandResponse.swift in Sources */,
 				717897B11E3175E800CB5B5A /* TealiumAttributionConstants.swift in Sources */,
 				717897B21E3175E800CB5B5A /* TealiumAppDataConstants.swift in Sources */,
 				7153AE0E1E773AD40020CDA5 /* TealiumRemoteCommandsModule.swift in Sources */,

--- a/tealium/remotecommands/TealiumRemoteCommandResponse.swift
+++ b/tealium/remotecommands/TealiumRemoteCommandResponse.swift
@@ -17,13 +17,14 @@ enum TealiumRemoteCommandResponseError : Error {
 
 class TealiumRemoteCommandResponse : CustomStringConvertible {
     
-    var status : TealiumRemoteCommandStatusCode = .unknown
+    var status : Int = TealiumRemoteCommandStatusCode.noContent.rawValue
     var urlRequest : URLRequest
     var urlResponse : URLResponse?
+    var data: Data?
     var error : Error?
     
     var description : String {
-        return "<TealiumRemoteCommandResponse: config:\(config()), status:\(status), payload:\(payload()), response: \(urlResponse), error:\(error)>"
+        return "<TealiumRemoteCommandResponse: config:\(config()), status:\(status), payload:\(payload()), response: \(urlResponse), data:\(data) error:\(error)>"
     }
     
     convenience init?(urlString: String) {


### PR DESCRIPTION
* Renamed file with typo (RemoteCommandReponse)
* Switched text status code on http response from string to int (per the spec, it should be passing the actual status code, e.g. 200, 404 etc.
* Now passes back the actual data returned from the http request, instead of just the headers