### PR TITLE
Fix issue on TealiumConnectivity

### DIFF
--- a/tealium/connectivity/TealiumConnectivity.swift
+++ b/tealium/connectivity/TealiumConnectivity.swift
@@ -49,7 +49,8 @@ public class TealiumConnectivity {
             }
         }
 
-        var flags: SCNetworkReachabilityFlags = SCNetworkReachabilityFlags(rawValue: 0)
+        var flags: SCNetworkReachabilityFlags = SCNetworkReachabilityFlags()
+        SCNetworkReachabilityGetFlags(defaultRouteReachability!, &flags)
         #if os(OSX)
             connectionType = TealiumConnectivityKey.connectionTypeWifi
         #else


### PR DESCRIPTION
I noticed that `tealium-swift` always reported I was on wifi even if I was using cellular data.
I figured the problem was that the flags' OptionSet was instantiated but never filled with the actual flags.
This fix should solve the issue.