### PR TITLE
Commit removal of 'weak' reference to the response within the httpCom…

### DIFF
--- a/tealium/remotecommands/TealiumRemoteCommandsModule.swift
+++ b/tealium/remotecommands/TealiumRemoteCommandsModule.swift
@@ -424,12 +424,8 @@ class TealiumRemoteHTTPCommand: TealiumRemoteCommand {
                     return
                 }
 
-                weak var weakResponse = response
                 let task = URLSession.shared.dataTask(with: request,
                                                       completionHandler: { data, urlResponse, error in
-                            guard let response = weakResponse else {
-                                return
-                            }
                             // Legacy status reporting
                             if let err = error {
                                 response.error = err


### PR DESCRIPTION
…mand method - TealiumRemoteCommandModule.swift

The weakResponse was returning nil and preventing the rest of the
httpCommand block from executing and returning the expected http
response. Suspicion is that this was added a while back in an effort to
avoid memory leaks, but when tested after removing, no new leaks were
found.