### PR TITLE
Fixed deprecated warning for Hashable protocol function in TealiumModule.swift

### DIFF
--- a/tealium/core/TealiumModule.swift
+++ b/tealium/core/TealiumModule.swift
@@ -204,8 +204,8 @@ extension TealiumModule: Equatable {
 
 extension TealiumModule: Hashable {
 
-    public var hashValue: Int {
-        return type(of: self).moduleConfig().name.hash
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(type(of: self).moduleConfig().name)
     }
 
 }


### PR DESCRIPTION
Hey,

there was an warning with Xcode 10.2 for the ```TealiumModule.swift``` file:

```
'Hashable.hashValue' is deprecated as a protocol requirement; conform type 'TealiumModule' to 'Hashable' by implementing 'hash(into:)' instead
```

Fixed the warning by removing the current ```hashValue``` getter:

```
    public var hashValue: Int {
        return type(of: self).moduleConfig().name.hash
    }
```

and added the new ```hash(into:)``` function:
```
    public func hash(into hasher: inout Hasher) {
        hasher.combine(type(of: self).moduleConfig().name)
    }
```