### PR TITLE
1.7.3

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
-github "tealium/plcrashreporter"
+# github "tealium/plcrashreporter"
+binary "https://tags.tiqcdn.com/dle/tealiummobile/tealium-ios-carthage/tealium-carthage-plcrashreporter.json"


### PR DESCRIPTION
Fix for PLCrashReporter dependency with Xcode 11. Now uses a pre-built framework instead of building from source.