### PR TITLE
Fix an issue where device-names.json file was being compiled

### DIFF
--- a/tealium-swift.podspec
+++ b/tealium-swift.podspec
@@ -89,20 +89,20 @@ Pod::Spec.new do |s|
   #  For header files it will include any header in the folder.
   #  Not including the public_header_files will make all headers public.
   #
-  
+
   s.default_subspec = "TealiumFull"
 
   s.subspec "TealiumFull" do |full|
-    full.source_files  = "tealium/core/**/*","tealium/collectors/**/*","tealium/dispatchers/**/*","tealium/scripts/*"
+    full.source_files  = "tealium/core/**/*.swift","tealium/collectors/**/*","tealium/dispatchers/**/*","tealium/scripts/*"
     full.ios.exclude_files = "tealium/scripts/*", "tealium/collectors/crash/*"
-    full.tvos.exclude_files = "tealium/dispatchers/tagmanagement/*","tealium/dispatchers/remotecommands/*","tealium/collectors/attribution/*","tealium/scripts/*","tealium/collectors/location/*" 
+    full.tvos.exclude_files = "tealium/dispatchers/tagmanagement/*","tealium/dispatchers/remotecommands/*","tealium/collectors/attribution/*","tealium/scripts/*","tealium/collectors/location/*"
     full.watchos.exclude_files = "tealium/dispatchers/tagmanagement/*","tealium/collectors/autotracking/*","tealium/dispatchers/remotecommands/*","tealium/collectors/attribution/*","tealium/scripts/*","tealium/collectors/location/*"
     full.osx.exclude_files = "tealium/dispatchers/tagmanagement/*","tealium/collectors/autotracking/*","tealium/dispatchers/remotecommands/*","tealium/collectors/attribution/*","tealium/scripts/*","tealium/collectors/location/*"
     full.resources = "tealium/core/devicedata/device-names.json"
   end
 
   s.subspec "Core" do |core|
-    core.source_files  = "tealium/core/**/*"
+    core.source_files  = "tealium/core/**/*.swift"
   end
 
   s.subspec "Attribution" do |attribution|

--- a/tealium-swift.podspec
+++ b/tealium-swift.podspec
@@ -103,6 +103,7 @@ Pod::Spec.new do |s|
 
   s.subspec "Core" do |core|
     core.source_files  = "tealium/core/**/*.swift"
+    core.resources = "tealium/core/devicedata/device-names.json"
   end
 
   s.subspec "Attribution" do |attribution|


### PR DESCRIPTION
Since upgrading to 2.0.0 I've been seeing a compilation warning when building my project:

`no rule to process file '/Users/will.mcginty/Developer/ios-robert-half/Pods/tealium-swift/tealium/core/devicedata/device-names.json' of type 'text.json' for architecture 'x86_64' `

This can also be seen when using `pod spec lint`:

```bash 
% pod spec lint --subspec=Core

 -> tealium-swift/Core (2.0.0)
    - NOTE  | [tealium-swift/Core] xcodebuild:  note: Using new build system
    - NOTE  | [tealium-swift/Core] xcodebuild:  note: Building targets in parallel
    - NOTE  | [tealium-swift/Core] xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | [tealium-swift/Core] xcodebuild:  note: Planning build
    - NOTE  | [tealium-swift/Core] xcodebuild:  note: Constructing build description
    - NOTE  | [tealium-swift/Core] xcodebuild:  warning: no rule to process file 'tealium-swift/tealium/core/devicedata/device-names.json' of type 'text.json' for architecture 'arm64' (in target 'tealium-swift' from project 'Pods')
    - NOTE  | [tealium-swift/Core] xcodebuild:  warning: no rule to process file 'tealium-swift/tealium/core/devicedata/device-names.json' of type 'text.json' for architecture 'x86_64' (in target 'tealium-swift' from project 'Pods')
    - NOTE  | [tealium-swift/Core] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file and one is not being generated automatically. (in target 'App' from project 'App')
    - NOTE  | [tealium-swift/Core] xcodebuild:  warning: no rule to process file 'tealium-swift/tealium/core/devicedata/device-names.json' of type 'text.json' for architecture 'i386' (in target 'tealium-swift' from project 'Pods')
    - NOTE  | [tealium-swift/Core] xcodebuild:  note: Using codesigning identity override: 

Analyzed 1 podspec.

tealium-swift.podspec passed validation.
```

It looks as though the 'device-names.json' file is mistakenly being included in the source files for the Core and Full subspecs leading to the build error.

Limiting the source files of the Full/Core subspecs to Swift files, and adding the device-names.json file as a resource seems to fix the issue.
