### PR TITLE
Bug fixes and enhancements: MT-512, MT-517, MT-523

### DIFF
--- a/builder/tealium-swift.xcodeproj/project.pbxproj
+++ b/builder/tealium-swift.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		CF3C1AFC2473251900A4DEE9 /* ConsentManagerModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D73E7A0C209B0601001D05D3 /* ConsentManagerModuleTests.swift */; };
 		CF3C1AFE2473252000A4DEE9 /* ConsentMockDiskStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D788A59C2321392D00BC6D60 /* ConsentMockDiskStorage.swift */; };
 		CF3C1AFF2473252000A4DEE9 /* ConsentMockDiskStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D788A59C2321392D00BC6D60 /* ConsentMockDiskStorage.swift */; };
+		CF6E3ADC25F9356900900902 /* Tealium+Encodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF6E3ADB25F9356900900902 /* Tealium+Encodable.swift */; };
 		CF6E9E31249AEFCE0032A663 /* RemoteCommandResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF6E9E30249AEFCE0032A663 /* RemoteCommandResponseTests.swift */; };
 		CF6E9E33249AEFD90032A663 /* RemoteCommandExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF6E9E32249AEFD90032A663 /* RemoteCommandExtensionsTests.swift */; };
 		CF75E54B248827430086FF26 /* MockRemoteCommandsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF75E549248827210086FF26 /* MockRemoteCommandsManager.swift */; };
@@ -1361,6 +1362,7 @@
 		CF3A591124DB469900A4851D /* RemoteCommandsManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteCommandsManagerTests.swift; sourceTree = "<group>"; };
 		CF3A591324DB46AF00A4851D /* RemoteCommandConfigTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteCommandConfigTests.swift; sourceTree = "<group>"; };
 		CF3A591724DB49C000A4851D /* MockRemoteCommandsDiskStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockRemoteCommandsDiskStorage.swift; sourceTree = "<group>"; };
+		CF6E3ADB25F9356900900902 /* Tealium+Encodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tealium+Encodable.swift"; sourceTree = "<group>"; };
 		CF6E9E30249AEFCE0032A663 /* RemoteCommandResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteCommandResponseTests.swift; sourceTree = "<group>"; };
 		CF6E9E32249AEFD90032A663 /* RemoteCommandExtensionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteCommandExtensionsTests.swift; sourceTree = "<group>"; };
 		CF75E549248827210086FF26 /* MockRemoteCommandsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRemoteCommandsManager.swift; sourceTree = "<group>"; };
@@ -2645,6 +2647,7 @@
 				4BD9037124F5CED40041EFA0 /* Double+Tealium.swift */,
 				CFB6E75C255DF033007F2773 /* TimedEvent+Tealium.swift */,
 				CFA0C0AF252FE26F009CDF33 /* Migrator.swift */,
+				CF6E3ADB25F9356900900902 /* Tealium+Encodable.swift */,
 			);
 			path = utils;
 			sourceTree = "<group>";
@@ -4139,6 +4142,7 @@
 				43DE56328E0F008503D09038 /* AnyEncodable.swift in Sources */,
 				D7B1A2632462F1630058028D /* DispatchListener.swift in Sources */,
 				D79A1CAA244A0FF500BBA8B3 /* DeviceDataCarrierInfo.swift in Sources */,
+				CF6E3ADC25F9356900900902 /* Tealium+Encodable.swift in Sources */,
 				D79A1C90244A0F3D00BBA8B3 /* ConnectivityDelegate.swift in Sources */,
 				43DE590D11729BCF1EF22124 /* AnyCodable.swift in Sources */,
 				D7CCB57522C65B0600FF1103 /* TealiumDiskStorageConfig.swift in Sources */,

--- a/support/tests/TestTealiumHelper.swift
+++ b/support/tests/TestTealiumHelper.swift
@@ -216,3 +216,9 @@ extension Dictionary where Key: ExpressibleByStringLiteral, Value: Any {
     }
 
 }
+
+extension Dictionary where Key == String, Value == Any {
+    func equal(to dictionary: [String: Any] ) -> Bool {
+        NSDictionary(dictionary: self).isEqual(to: dictionary)
+    }
+}

--- a/support/tests/test_tealium_core/MigratorTests.swift
+++ b/support/tests/test_tealium_core/MigratorTests.swift
@@ -212,9 +212,3 @@ class MigratorTests: XCTestCase {
     }
 
 }
-
-fileprivate extension Dictionary where Key == String, Value == Any {
-    func equal(to dictionary: [String: Any] ) -> Bool {
-        NSDictionary(dictionary: self).isEqual(to: dictionary)
-    }
-}

--- a/support/tests/test_tealium_core/TealiumRequestsTests.swift
+++ b/support/tests/test_tealium_core/TealiumRequestsTests.swift
@@ -73,5 +73,46 @@ class TealiumRequestsTests: XCTestCase {
         let result = track.extractLookupValue(for: "hello") as? Int
         XCTAssertEqual(result, 10)
     }
+    
+    func testTealiumView_ContainsExpectedInfo_NoCustomData() {
+        let view = TealiumView("screenName")
+        var result = view.trackRequest.trackDictionary
+        XCTAssertNotNil(result[TealiumKey.requestUUID] as! String)
+        result[TealiumKey.requestUUID] = nil
+        XCTAssertTrue(result.equal(to: ["tealium_event": "screenName",
+                                        "tealium_event_type": "view",
+                                        "screen_title": "screenName"]))
+    }
+    
+    func testTealiumView_ContainsExpectedInfo_WithCustomData() {
+        let view = TealiumView("screenName", dataLayer: ["hello": "world"])
+        var result = view.trackRequest.trackDictionary
+        XCTAssertNotNil(result[TealiumKey.requestUUID] as! String)
+        result[TealiumKey.requestUUID] = nil
+        XCTAssertTrue(result.equal(to: ["tealium_event": "screenName",
+                                        "tealium_event_type": "view",
+                                        "screen_title": "screenName",
+                                        "hello": "world"]))
+    }
+    
+    func testTealiumEvent_ContainsExpectedInfo_NoCustomData() {
+        let event = TealiumEvent("eventName")
+        var result = event.trackRequest.trackDictionary
+        XCTAssertNotNil(result[TealiumKey.requestUUID] as! String)
+        result[TealiumKey.requestUUID] = nil
+        XCTAssertTrue(result.equal(to: ["tealium_event": "eventName",
+                                        "tealium_event_type": "event"]))
+    }
+    
+    func testTealiumEvent_ContainsExpectedInfo_WithCustomData() {
+        let event = TealiumEvent("eventName", dataLayer: ["hello": "world"])
+        var result = event.trackRequest.trackDictionary
+        XCTAssertNotNil(result[TealiumKey.requestUUID] as! String)
+        result[TealiumKey.requestUUID] = nil
+        XCTAssertTrue(result.equal(to: ["tealium_event": "eventName",
+                                        "tealium_event_type": "event",
+                                        "hello": "world"]))
+    }
+
 
 }

--- a/support/tests/test_tealium_core/TimedEventTests.swift
+++ b/support/tests/test_tealium_core/TimedEventTests.swift
@@ -84,9 +84,3 @@ class TimedEventTests: XCTestCase {
     }
 
 }
-
-fileprivate extension Dictionary where Key == String, Value == Any {
-    func equal(to dictionary: [String: Any] ) -> Bool {
-        NSDictionary(dictionary: self).isEqual(to: dictionary)
-    }
-}

--- a/support/tests/test_tealium_core/consent_manager/ConsentManagerTests.swift
+++ b/support/tests/test_tealium_core/consent_manager/ConsentManagerTests.swift
@@ -125,6 +125,10 @@ class ConsentManagerTests: XCTestCase {
             if trackInfo["tealium_event"] as? String == ConsentKey.gdprConsentCookieEventName {
                 return
             }
+            
+            XCTAssertNil(trackInfo["call_type"])
+            XCTAssertNotNil(trackInfo[TealiumKey.eventType])
+            
             if let categories = trackInfo["consent_categories"] as? [String], categories.count > 0 {
                 let catEnum = TealiumConsentCategories.consentCategoriesStringArrayToEnum(categories)
                 XCTAssertTrue([TealiumConsentCategories.cdp] == catEnum, "Consent Manager Test: testTrackUserConsentPreferences: Categories array contained unexpected values")

--- a/support/tests/test_tealium_remotecommands/RemoteCommandsModuleTests.swift
+++ b/support/tests/test_tealium_remotecommands/RemoteCommandsModuleTests.swift
@@ -160,6 +160,12 @@ class RemoteCommandsModuleTests: XCTestCase {
         XCTAssertEqual(remoteCommandsManager.triggerCount, 0)
         XCTAssertEqual(remoteCommandsManager.refreshCount, 0)
     }
+    
+    func testTealiumEventType() {
+        let request = TealiumRemoteAPIRequest(trackRequest: TealiumTrackRequest(data: ["test": "data"]))
+        XCTAssertNil(request.trackRequest.trackDictionary["call_type"])
+        XCTAssertEqual(request.trackRequest.trackDictionary[TealiumKey.eventType] as! String, "remote_api")
+    }
 
 }
 

--- a/support/tests/test_tealium_tagmanagement/TagManagementUtilsTests.swift
+++ b/support/tests/test_tealium_tagmanagement/TagManagementUtilsTests.swift
@@ -21,7 +21,7 @@ class TagManagementUtilsTests: XCTestCase {
     }
 
     func testGetLegacyTypeView() {
-        let eventType = "call_type"
+        let eventType = "tealium_event_type"
         let viewValue = "view"
         let viewDictionary: [String: Any] = [eventType: viewValue]
         let viewResult = viewDictionary.legacyType
@@ -30,7 +30,7 @@ class TagManagementUtilsTests: XCTestCase {
     }
 
     func testGetLegacyTypeEvent() {
-        let eventType = "call_type"
+        let eventType = "tealium_event_type"
         let linkValue = "link"
         let eventDictionary: [String: Any] = [eventType: linkValue]
         let eventResult = eventDictionary.legacyType
@@ -39,7 +39,7 @@ class TagManagementUtilsTests: XCTestCase {
     }
 
     func testRandomEventType() {
-        let eventType = "call_type"
+        let eventType = "tealium_event_type"
         let anyValue = "any"
         let eventDictionary: [String: Any] = [eventType: anyValue]
         let eventResult = eventDictionary.legacyType

--- a/tealium-swift.podspec
+++ b/tealium-swift.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.name         = "tealium-swift"
   s.module_name  = "TealiumSwift"
-  s.version      = "2.2.2"
+  s.version      = "2.3.0"
   s.summary      = "Tealium Swift Integration Library"
 
   # This description is used to generate tags and improve search results.

--- a/tealium/collectors/lifecycle/LifecycleModule.swift
+++ b/tealium/collectors/lifecycle/LifecycleModule.swift
@@ -90,7 +90,9 @@ public class LifecycleModule: Collector {
         guard var lifecycle = self.lifecycle else {
             return
         }
-
+        if type != .launch {
+            lifecycleData[LifecycleKey.didDetectCrash] = nil
+        }
         switch type {
         case .launch:
             if enabledPrior == true { return }

--- a/tealium/core/TealiumConstants.swift
+++ b/tealium/core/TealiumConstants.swift
@@ -54,7 +54,6 @@ public enum TealiumKey {
     public static let profile = "tealium_profile"
     public static let environment = "tealium_environment"
     public static let event = "tealium_event"
-    public static let callType = "call_type"
     public static let screenTitle = "screen_title"
     public static let eventType = "tealium_event_type"
     public static let libraryName = "tealium_library_name"
@@ -96,7 +95,7 @@ public enum TealiumKey {
     // swiftlint:enable identifier_name
     public static let errorHeaderKey = "X-Error"
     public static let diskStorageDirectory = "disk_storage_directory"
-    public static let remoteAPICallType = "remote_api"
+    public static let remoteAPIEventType = "remote_api"
     public static let publishSettings = "remote_publish_settings"
     public static let publishSettingsURL = "publish_settings_url"
     public static let publishSettingsProfile = "publish_settings_profile"

--- a/tealium/core/TealiumConstants.swift
+++ b/tealium/core/TealiumConstants.swift
@@ -15,7 +15,7 @@ public enum Dispatchers {}
 
 public enum TealiumValue {
     public static let libraryName = "swift"
-    public static let libraryVersion = "2.2.2"
+    public static let libraryVersion = "2.3.0"
     // This is the current limit for performance reasons. May be increased in future
     public static let maxEventBatchSize = 10
     public static let defaultMinimumDiskSpace: Int32 = 20_000_000

--- a/tealium/core/TealiumRequests.swift
+++ b/tealium/core/TealiumRequests.swift
@@ -78,7 +78,7 @@ public struct TealiumRemoteAPIRequest: TealiumRequest {
 
     public init(trackRequest: TealiumTrackRequest) {
         var trackRequestData = trackRequest.trackDictionary
-        trackRequestData[TealiumKey.callType] = TealiumKey.remoteAPICallType
+        trackRequestData[TealiumKey.eventType] = TealiumKey.remoteAPIEventType
         self.trackRequest = TealiumTrackRequest(data: trackRequestData)
     }
 
@@ -300,6 +300,7 @@ public struct TealiumEvent: TealiumDispatch {
     public var trackRequest: TealiumTrackRequest {
         var data = dataLayer ?? [String: Any]()
         data[TealiumKey.event] = eventName
+        data[TealiumKey.eventType] = TealiumTrackType.event.description
         return TealiumTrackRequest(data: data)
     }
 }
@@ -317,7 +318,7 @@ public struct TealiumView: TealiumDispatch {
     public var trackRequest: TealiumTrackRequest {
         var data = dataLayer ?? [String: Any]()
         data[TealiumKey.event] = viewName
-        data[TealiumKey.callType] = TealiumTrackType.view.description
+        data[TealiumKey.eventType] = TealiumTrackType.view.description
         data[TealiumKey.screenTitle] = viewName
         return TealiumTrackRequest(data: data)
     }

--- a/tealium/core/consentmanager/ConsentManager.swift
+++ b/tealium/core/consentmanager/ConsentManager.swift
@@ -115,7 +115,7 @@ public class ConsentManager {
             // this track call must only be sent if "Log Consent Changes" is enabled and user has consented
             if consentLoggingEnabled, currentPolicy.shouldLogConsentStatus {
                 // call type must be set to override "link" or "view"
-                consentData[TealiumKey.callType] = consentData[TealiumKey.event]
+                consentData[TealiumKey.eventType] = consentData[TealiumKey.event]
                 delegate?.requestTrack(TealiumTrackRequest(data: consentData))
             }
             // in all cases, update the cookie data in TiQ/webview
@@ -134,7 +134,7 @@ public class ConsentManager {
             }
             // collect module ignores this hit
             consentData[TealiumKey.event] = currentPolicy.updateConsentCookieEventName
-            consentData[TealiumKey.callType] = currentPolicy.updateConsentCookieEventName
+            consentData[TealiumKey.eventType] = currentPolicy.updateConsentCookieEventName
             delegate?.requestTrack(TealiumTrackRequest(data: consentData))
         }
     }

--- a/tealium/core/consentmanager/ConsentPolicies.swift
+++ b/tealium/core/consentmanager/ConsentPolicies.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-protocol ConsentPolicy {
+public protocol ConsentPolicy {
     init (_ preferences: UserConsentPreferences)
     var defaultConsentExpiry: (time: Int, unit: TimeUnit) { get }
     var shouldUpdateConsentCookie: Bool { get }

--- a/tealium/core/datalayer/TealiumTrace.swift
+++ b/tealium/core/datalayer/TealiumTrace.swift
@@ -42,7 +42,7 @@ public extension Tealium {
             return
         }
         let dispatch = TealiumEvent(TealiumKey.killVisitorSession,
-                                    dataLayer: [TealiumKey.killVisitorSessionEvent: TealiumKey.killVisitorSession, TealiumKey.callType: TealiumKey.killVisitorSession, TealiumKey.traceId: traceId])
+                                    dataLayer: [TealiumKey.killVisitorSessionEvent: TealiumKey.killVisitorSession, TealiumKey.eventType: TealiumKey.killVisitorSession, TealiumKey.traceId: traceId])
         self.track(dispatch)
     }
 

--- a/tealium/core/utils/Tealium+Encodable.swift
+++ b/tealium/core/utils/Tealium+Encodable.swift
@@ -1,0 +1,16 @@
+//
+//  Tealium+Encodable.swift
+//  TealiumCore
+//
+//  Copyright © 2021 Tealium, Inc. All rights reserved.
+//
+
+import Foundation
+
+public extension Encodable {
+    /// - Returns: `[String: Any]` of `Codable` type
+    var encoded: [String: Any]? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)).flatMap { $0 as? [String: Any] }
+    }
+}

--- a/tealium/dispatchers/tagmanagement/TagManagementUtils.swift
+++ b/tealium/dispatchers/tagmanagement/TagManagementUtils.swift
@@ -24,11 +24,15 @@ extension Dictionary where Key == String, Value == Any {
         return "utag.track(\'\(trackType)\',\(encodedPayload))"
     }
 
-    /// Gets the call type from the track call. Defaults to "link" unless callType is specified
+    /// Gets the tealium event type from the track call. Defaults to "link" unless `eventType` is specified
     ///
-    /// - Returns: `String` containing the type of event based on the "call_type" variable in the dictionary.
+    /// - Returns: `String` containing the type of event based on the `tealium_event_type` variable in the dictionary.
     var legacyType: String {
-        return self[TealiumKey.callType] as? String ?? "link"
+        guard let eventType = self[TealiumKey.eventType] as? String,
+              eventType != "event" else {
+            return "link"
+        }
+        return eventType
     }
 }
 #endif


### PR DESCRIPTION
* Removed `call_type` and replaced with `tealium_event_type` to be more in line with the Kotlin library. When the event type is a standard track and not a screen view, the `tealium_event_type` is now "event" instead of "link". 
* Changed `ConsentPolicy` access to `public` in order to allow for custom `ConsentPolicies`
* Fixed a bug in the lifecycle module that was sending the `lifecycle_diddetectcrash=true` on sleep/wake events in a session after a crash. Now, this variable will only be present on launch.