### PR TITLE
Update Regex to Allow More Uncommon Valid URLs

### DIFF
--- a/tealium/dispatchers/collect/CollectEventDispatcher.swift
+++ b/tealium/dispatchers/collect/CollectEventDispatcher.swift
@@ -71,7 +71,7 @@ class CollectEventDispatcher: CollectProtocol {
     /// - Parameter url: `String` containing a URL to be validated
     /// - Returns: `Bool` `true` if URL is a valid web address
     static func isValidUrl(_ url: String) -> Bool {
-        let urlRegexPattern = "^(https?://)?(www\\.)?([-a-z0-9]{1,63}\\.)*?[a-z0-9][-a-z0-9]{0,61}[a-z0-9]\\.[a-z]{2,6}(/[-\\w@\\+\\.~#\\?&/=%]*)?$"
+        let urlRegexPattern = "^((https?)://)?(([a-zA-Z]\\.?)+?|(([0-9]{1,3}\\.){3}[0-9]{1,3}))(:[0-9]{1,5})?(/[-\\w@\\+\\.~#\\?&/=%]*)?$"
         guard let validURLRegex = try? NSRegularExpression(pattern: urlRegexPattern, options: []) else {
             return false
         }


### PR DESCRIPTION
This allows more uncommon URLs to be used, such as localhost, local IPs, and URLs with ports.
Tested using regexr.com with the following text:

# Plain IP Addresses
## Bad
1
12
127
127.
127.0
127.0.0
127.0.0.
## Good
127.0.0.1
127.0.0.1/
127.0.0.1/a
127.0.0.1/a/
127.0.0.1/a/b
127.0.0.1/a/b?
127.0.0.1/a/b?z
127.0.0.1/a/b?z=
127.0.0.1/a/b?z=%

# IP address with Port
## Bad
127.0.0.1:
127.0.0.1:123456
## Good
127.0.0.1:1
127.0.0.1:12
127.0.0.1:123
127.0.0.1:1234
127.0.0.1:12345
127.0.0.1:12345/
127.0.0.1:12345/a
127.0.0.1:12345/a/
127.0.0.1:12345/a/b
127.0.0.1:12345/a/b?
127.0.0.1:12345/a/b?z
127.0.0.1:12345/a/b?z=
127.0.0.1:12345/a/b?z=%

# IP address with Port and HTTP
## Bad
file:127.0.0.1
html://127.0.0.1
http:127.0.0.1
httpd://127.0.0.1
## Good
http://127.0.0.1:1
http://127.0.0.1:12
http://127.0.0.1:123
http://127.0.0.1:1234
http://127.0.0.1:12345
http://127.0.0.1:12345/
http://127.0.0.1:12345/a
http://127.0.0.1:12345/a/
http://127.0.0.1:12345/a/b
http://127.0.0.1:12345/a/b?
http://127.0.0.1:12345/a/b?z
http://127.0.0.1:12345/a/b?z=
http://127.0.0.1:12345/a/b?z=%

# IP address with Port and HTTPS
## Bad
file:127.0.0.1
https:127.0.0.1
htmls://127.0.0.1
htts://127.0.0.1
## Good
https://127.0.0.1:1
https://127.0.0.1:12
https://127.0.0.1:123
https://127.0.0.1:1234
https://127.0.0.1:12345
https://127.0.0.1:12345/
https://127.0.0.1:12345/a
https://127.0.0.1:12345/a/
https://127.0.0.1:12345/a/b
https://127.0.0.1:12345/a/b?
https://127.0.0.1:12345/a/b?z
https://127.0.0.1:12345/a/b?z=
https://127.0.0.1:12345/a/b?z=%

# No TLD
## Good
http://localhost/
https://localhost/
localhost
myMac.local

# Standard URL
## Good
http://google.co
http://google.com
http://google.co.uk
http://www.google.co
http://www.google.com
http://www.google.co.uk
http://www.google.co.uk:12345
https://google.co
https://google.com
https://google.co.uk
https://www.google.co
https://www.google.com
https://www.google.co.uk
https://www.google.co.uk:12345

# Path and Query
## Good
http://google.com/a/b/c/d/e/f/g
http://google.com/a/b/c?
http://google.com/a/b/c?z=2&y=hello
http://google.com/a/b/c?text=%2FHi%2F
https://google.com/a/b/c/d/e/f/g
https://google.com/a/b/c?
https://google.com/a/b/c?z=2&y=hello
https://google.com/a/b/c?text=%2FHi%2F

# Email
## Bad
hello@hello.com
http://hello@hello.com
http://google.com@hello

# Misc.
## Bad
file:c:test
ftp://test.com/
git:test.com:path/to/res.git
ssh:google.com