### PR TITLE
[MT-797] make RemoteHTTPCommand use the relative manager url Session

### DIFF
--- a/support/tests/test_tealium_remotecommands/RemoteCommandsModuleTests.swift
+++ b/support/tests/test_tealium_remotecommands/RemoteCommandsModuleTests.swift
@@ -32,12 +32,9 @@ class RemoteCommandsModuleTests: XCTestCase {
     func testDisableHTTPCommandsViaConfig() {
         config.remoteHTTPCommandDisabled = true
         module = RemoteCommandsModule(config: config, delegate: self, remoteCommands: remoteCommandsManager)
-        guard let remoteCommands = module.remoteCommands else {
-            XCTFail("remoteCommands array should not be nil")
-            return
-        }
+        let remoteCommands = module.remoteCommands
 
-        XCTAssertTrue((remoteCommands.webviewCommands.isEmpty), "Unexpected number of reserve commands found: \(String(describing: module.remoteCommands?.webviewCommands))")
+        XCTAssertTrue((remoteCommands.webviewCommands.isEmpty), "Unexpected number of reserve commands found: \(String(describing: module.remoteCommands.webviewCommands))")
     }
 
     //Integration Test
@@ -50,7 +47,7 @@ class RemoteCommandsModuleTests: XCTestCase {
         let commandId = "test"
         let remoteCommand = RemoteCommand(commandId: commandId,
                                           description: "") { _ in }
-        module.remoteCommands?.add(remoteCommand)
+        module.remoteCommands.add(remoteCommand)
 
         // Send trigger
         let urlString = "tealium://\(commandId)?request={\"config\":{}, \"payload\":{}}"
@@ -64,7 +61,7 @@ class RemoteCommandsModuleTests: XCTestCase {
         }
         let urlRequest = URLRequest(url: url)
         let request = TealiumRemoteCommandRequest(data: [TealiumKey.tagmanagementNotification: urlRequest])
-        module.remoteCommands?.moduleDelegate?.processRemoteCommandRequest(request)
+        module.remoteCommands.moduleDelegate?.processRemoteCommandRequest(request)
 
         waitForExpectations(timeout: 5.0, handler: nil)
 
@@ -74,7 +71,7 @@ class RemoteCommandsModuleTests: XCTestCase {
     func testUpdateConfig() {
         config.remoteHTTPCommandDisabled = false
         module = RemoteCommandsModule(config: config, delegate: self, completion: { _ in })
-        XCTAssertEqual(module.remoteCommands?.webviewCommands.count, 1)
+        XCTAssertEqual(module.remoteCommands.webviewCommands.count, 1)
         var newRemoteCommand = RemoteCommand(commandId: "test", description: "test") { _ in
 
         }
@@ -84,7 +81,7 @@ class RemoteCommandsModuleTests: XCTestCase {
         newConfig.addRemoteCommand(newJSONCommand)
         var updateRequest = TealiumUpdateConfigRequest(config: newConfig)
         module.updateConfig(updateRequest)
-        XCTAssertEqual(module.remoteCommands?.webviewCommands.count, 1)
+        XCTAssertEqual(module.remoteCommands.webviewCommands.count, 1)
         newRemoteCommand = RemoteCommand(commandId: "test2", description: "test") { _ in
 
         }
@@ -94,7 +91,7 @@ class RemoteCommandsModuleTests: XCTestCase {
         newConfig.addRemoteCommand(newJSONCommand)
         updateRequest = TealiumUpdateConfigRequest(config: newConfig)
         module.updateConfig(updateRequest)
-        XCTAssertEqual(module.remoteCommands?.webviewCommands.count, 1)
+        XCTAssertEqual(module.remoteCommands.webviewCommands.count, 1)
         //XCTAssertEqual(module.remoteCommands?.jsonCommands.count, 1)
 
         newConfig.remoteCommands = nil
@@ -102,7 +99,7 @@ class RemoteCommandsModuleTests: XCTestCase {
         newConfig.addRemoteCommand(newJSONCommand)
         updateRequest = TealiumUpdateConfigRequest(config: newConfig)
         module.updateConfig(updateRequest)
-        XCTAssertEqual(module.remoteCommands?.webviewCommands.count, 1)
+        XCTAssertEqual(module.remoteCommands.webviewCommands.count, 1)
         //XCTAssertEqual(module.remoteCommands?.jsonCommands.count, 1)
     }
 
@@ -116,19 +113,19 @@ class RemoteCommandsModuleTests: XCTestCase {
     func testInitializeWithDefaultCommands() {
         config.remoteHTTPCommandDisabled = false
         module = RemoteCommandsModule(config: config, delegate: self, completion: { _ in })
-        XCTAssertEqual(module.remoteCommands?.webviewCommands.count, 1)
+        XCTAssertEqual(module.remoteCommands.webviewCommands.count, 1)
     }
 
     func testInitializeDefaultCommandsDisabled() {
         config.remoteHTTPCommandDisabled = true
         module = RemoteCommandsModule(config: config, delegate: self, remoteCommands: remoteCommandsManager)
-        XCTAssertEqual(module.remoteCommands?.webviewCommands.count, 0)
+        XCTAssertEqual(module.remoteCommands.webviewCommands.count, 0)
     }
 
     func testDynamicTrackWithWebViewCommand() {
         let request = TealiumRemoteCommandRequest(data: ["com.tealium.tagmanagement.urlrequest": "data"])
         module = RemoteCommandsModule(config: config, delegate: self, remoteCommands: remoteCommandsManager)
-        module.remoteCommands?.add(remoteCommand)
+        module.remoteCommands.add(remoteCommand)
         module.dynamicTrack(request, completion: nil)
         XCTAssertEqual(remoteCommandsManager.triggerCount, 1)
         XCTAssertEqual(remoteCommandsManager.refreshCount, 0)

--- a/support/tests/test_tealium_remotecommands/RemoteHTTPCommandTests.swift
+++ b/support/tests/test_tealium_remotecommands/RemoteHTTPCommandTests.swift
@@ -6,7 +6,7 @@
 //
 
 @testable import TealiumCore
-import TealiumRemoteCommands
+@testable import TealiumRemoteCommands
 import XCTest
 
 class RemoteHTTPCommandTests: XCTestCase {
@@ -99,8 +99,17 @@ class RemoteHTTPCommandTests: XCTestCase {
         let expected = RemoteCommand(commandId: "_http", description: "For processing tag-triggered HTTP requests") { _ in
             // ....
         }
-        let actual = RemoteHTTPCommand.create(with: nil)
+        let actual = RemoteHTTPCommand.create(with: nil, urlSession: URLSession(configuration: .ephemeral))
         XCTAssertEqual(expected.description, actual.description)
+    }
+    
+    func testDeinitRemoteCommandDoesntInvalidateTheSession() {
+        let mockURLSession = MockURLSession()
+        var command: RemoteCommandProtocol? = RemoteHTTPCommand.create(with: nil, urlSession: mockURLSession)
+        XCTAssertNotNil(command)
+        command = nil
+        XCTAssertFalse(mockURLSession.isInvalidated)
+        
     }
 
 }

--- a/support/tests/test_tealium_remotecommands/mocks/MockRemoteCommandsManager.swift
+++ b/support/tests/test_tealium_remotecommands/mocks/MockRemoteCommandsManager.swift
@@ -10,7 +10,7 @@ import Foundation
 @testable import TealiumRemoteCommands
 
 class MockRemoteCommandsManager: RemoteCommandsManagerProtocol {
-
+    var urlSession: URLSessionProtocol = URLSession(configuration: .ephemeral)
     var jsonCommands = [RemoteCommandProtocol]()
     var mockJSONCommand = MockJSONRemoteCommand()
     var webviewCommands = [RemoteCommandProtocol]()

--- a/support/tests/test_tealium_remotecommands/mocks/MockURLSession.swift
+++ b/support/tests/test_tealium_remotecommands/mocks/MockURLSession.swift
@@ -9,6 +9,7 @@ import Foundation
 @testable import TealiumCore
 
 class MockURLSession: URLSessionProtocol {
+    var isInvalidated = false
     func tealiumDataTask(with url: URL, completionHandler: @escaping (DataTaskResult) -> Void) -> URLSessionDataTaskProtocol {
         return DataTask(completionHandler: { data, response, error in
             if let error = error {
@@ -27,7 +28,9 @@ class MockURLSession: URLSessionProtocol {
         return DataTask(completionHandler: completionHandler, url: with.url!)
     }
 
-    func finishTealiumTasksAndInvalidate() { }
+    func finishTealiumTasksAndInvalidate() {
+        isInvalidated = true
+    }
 }
 
 class MockURLSession304: URLSessionProtocol {

--- a/tealium/dispatchers/remotecommands/RemoteCommand.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommand.swift
@@ -20,7 +20,6 @@ open class RemoteCommand: RemoteCommandProtocol {
     public var description: String?
     public var config: RemoteCommandConfig?
     public var type: RemoteCommandType
-    static var urlSession: URLSessionProtocol = URLSession(configuration: .ephemeral)
     public var completion: (_ response: RemoteCommandResponseProtocol) -> Void
 
     /// Constructor for a Tealium Remote Command.
@@ -190,10 +189,6 @@ open class RemoteCommand: RemoteCommandProtocol {
                 result[key]! += [value: dictionary.value]
             }
         }
-    }
-
-    deinit {
-        RemoteCommand.urlSession.finishTealiumTasksAndInvalidate()
     }
     
 }

--- a/tealium/dispatchers/remotecommands/RemoteCommandProtocols.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommandProtocols.swift
@@ -15,6 +15,7 @@ public protocol RemoteCommandsManagerProtocol {
     var jsonCommands: [RemoteCommandProtocol] { get set }
     var webviewCommands: [RemoteCommandProtocol] { get set }
     var moduleDelegate: ModuleDelegate? { get set }
+    var urlSession: URLSessionProtocol { get }
     func add(_ remoteCommand: RemoteCommandProtocol)
     func refresh(_ command: RemoteCommandProtocol, url: URL, file: String)
     func remove(commandWithId: String)

--- a/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
@@ -18,7 +18,7 @@ public class RemoteCommandsManager: NSObject, RemoteCommandsManagerProtocol {
     public var webviewCommands = [RemoteCommandProtocol]()
     weak public var moduleDelegate: ModuleDelegate?
     static var pendingResponses = Atomic<[String: Bool]>(value: [String: Bool]())
-    var urlSession: URLSessionProtocol?
+    public var urlSession: URLSessionProtocol
     var diskStorage: TealiumDiskStorageProtocol?
     var config: TealiumConfig
     var hasFetched = false
@@ -74,7 +74,7 @@ public class RemoteCommandsManager: NSObject, RemoteCommandsManagerProtocol {
             request.setValue(lastFetch.httpIfModifiedHeader, forHTTPHeaderField: "If-Modified-Since")
         }
         request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        self.urlSession?.tealiumDataTask(with: request) { data, response, _ in
+        self.urlSession.tealiumDataTask(with: request) { data, response, _ in
             guard let response = response as? HTTPURLResponse else {
                 completion(.failure(TealiumRemoteCommandsError.noResponse))
                 return
@@ -277,7 +277,7 @@ public class RemoteCommandsManager: NSObject, RemoteCommandsManagerProtocol {
     }
     
     deinit {
-        urlSession?.finishTealiumTasksAndInvalidate()
+        urlSession.finishTealiumTasksAndInvalidate()
     }
 }
 

--- a/tealium/dispatchers/remotecommands/RemoteHTTPCommand.swift
+++ b/tealium/dispatchers/remotecommands/RemoteHTTPCommand.swift
@@ -14,9 +14,9 @@ import TealiumCore
 public class RemoteHTTPCommand: RemoteCommand {
 
     /// - Returns:`RemoteHTTPCommand`
-    public class func create(with delegate: ModuleDelegate?) -> RemoteCommandProtocol {
+    class func create(with delegate: ModuleDelegate?, urlSession: URLSessionProtocol) -> RemoteCommandProtocol {
         weak var delegate = delegate
-        return RemoteCommand(commandId: RemoteCommandsKey.commandId,
+        return RemoteHTTPCommand(commandId: RemoteCommandsKey.commandId,
                              description: "For processing tag-triggered HTTP requests") { response in
             guard let response = response as? RemoteCommandResponse else {
                 return
@@ -26,26 +26,26 @@ public class RemoteHTTPCommand: RemoteCommand {
             guard let request = requestInfo.request else {
                 return
             }
-            RemoteCommand.urlSession.tealiumDataTask(with: request,
-                                                     completionHandler: { data, urlResponse, error in
-                                                        if let error = error {
-                                                            response.error = error
-                                                            response.status = RemoteCommandStatusCode.failure.rawValue
-                                                        } else {
-                                                            response.status = RemoteCommandStatusCode.success.rawValue
-                                                        }
-                                                        if data == nil {
-                                                            response.status = RemoteCommandStatusCode.noContent.rawValue
-                                                        }
-                                                        if urlResponse == nil {
-                                                            response.status = RemoteCommandStatusCode.failure.rawValue
-                                                        }
-                                                        response.urlResponse = urlResponse
-                                                        response.data = data
-                                                        RemoteCommand.sendRemoteCommandResponse(for: RemoteCommandsKey.commandId,
-                                                                                                response: response,
-                                                                                                delegate: delegate)
-                                                     }).resume()
+            urlSession.tealiumDataTask(with: request,
+                                       completionHandler: { data, urlResponse, error in
+                                        if let error = error {
+                                            response.error = error
+                                            response.status = RemoteCommandStatusCode.failure.rawValue
+                                        } else {
+                                            response.status = RemoteCommandStatusCode.success.rawValue
+                                        }
+                                        if data == nil {
+                                            response.status = RemoteCommandStatusCode.noContent.rawValue
+                                        }
+                                        if urlResponse == nil {
+                                            response.status = RemoteCommandStatusCode.failure.rawValue
+                                        }
+                                        response.urlResponse = urlResponse
+                                        response.data = data
+                                        RemoteCommand.sendRemoteCommandResponse(for: RemoteCommandsKey.commandId,
+                                                                                response: response,
+                                                                                delegate: delegate)
+                                       }).resume()
         }
     }
 
@@ -53,7 +53,7 @@ public class RemoteHTTPCommand: RemoteCommand {
     ///￼
     /// - Parameter payload: [String: Any] payload representing a set of key-value pairs to be sent with the URLRequest
     /// - Returns: `(URLRequest?, Error?)`
-    public class func httpRequest(from payload: [String: Any]) -> (request: URLRequest?, error: Error?) {
+    class func httpRequest(from payload: [String: Any]) -> (request: URLRequest?, error: Error?) {
         guard let urlStringValue = payload[RemoteCommandsKey.url] as? String else {
             return (nil, TealiumRemoteCommandResponseError.missingURLTarget)
         }
@@ -87,7 +87,7 @@ public class RemoteHTTPCommand: RemoteCommand {
     ///￼
     /// - Parameter dictionary: `[String:Any]`
     /// - Returns: Sorted `[URLQueryItem]` array by dictionary keys
-    public class func queryItems(from dictionary: [String: Any]) -> [URLQueryItem] {
+    class func queryItems(from dictionary: [String: Any]) -> [URLQueryItem] {
         var queryItems = [URLQueryItem]()
         dictionary.keys.sorted().forEach {
             let value = String(describing: dictionary[$0]!)


### PR DESCRIPTION
Avoid RemoteCommands to invalidate their shared session ahead of time
Remove the remoteCommandsManager optionality inside the RemoteCommandsModule class