### PR TITLE
[MT-796] only register for lowPowerModeNotification is batterySaver is enabled

### DIFF
--- a/support/tests/test_tealium_core/dispatch_manager/DispatchManagerTests.swift
+++ b/support/tests/test_tealium_core/dispatch_manager/DispatchManagerTests.swift
@@ -147,7 +147,31 @@ class DispatchQueueModuleTests: XCTestCase {
         dispatchManager.config = config
         XCTAssertFalse(dispatchManager.canQueueRequest(TealiumTrackRequest(data: ["tealium_event": "view"])))
     }
+    
+    func testRegisterForPowerNotificationsEnabled() {
+        
+        let config = TestTealiumHelper().getConfig()
+        config.batterySaverEnabled = true
+        config.logLevel = .silent
+        dispatchManager = DispatchManager(dispatchers: nil, dispatchValidators: nil, dispatchListeners: nil, connectivityManager: DispatchQueueModuleTests.connectivity, config: config, diskStorage: DispatchQueueMockDiskStorage())
+        
+        dispatchManager.registerForPowerNotifications()
+        #if os(iOS)
+        XCTAssertNotNil(dispatchManager.lowPowerNotificationObserver)
+        #else
+        XCTAssertNil(dispatchManager.lowPowerNotificationObserver) // Every other platform doesn't register
+        #endif
+    }
 
+    func testRegisterForPowerNotificationsDisabled() {
+        let config = TestTealiumHelper().getConfig()
+        config.batterySaverEnabled = false
+        config.logLevel = .silent
+        dispatchManager = DispatchManager(dispatchers: nil, dispatchValidators: nil, dispatchListeners: nil, connectivityManager: DispatchQueueModuleTests.connectivity, config: config, diskStorage: DispatchQueueMockDiskStorage())
+        
+        dispatchManager.registerForPowerNotifications()
+        XCTAssertNil(dispatchManager.lowPowerNotificationObserver)
+    }
 }
 
 class MockPersistentQueue: TealiumPersistentDispatchQueue {

--- a/tealium/core/dispatchmanager/TealiumDispatchQueueExtensions.swift
+++ b/tealium/core/dispatchmanager/TealiumDispatchQueueExtensions.swift
@@ -127,9 +127,12 @@ private func convertFromUIBackgroundTaskIdentifier(_ input: UIBackgroundTaskIden
 extension DispatchManager {
 
     func registerForPowerNotifications() {
-        #if os(macOS)
+        #if !os(iOS)
         self.lowPowerModeEnabled = false
         #else
+        guard config.batterySaverEnabled == true else {
+            return
+        }
         lowPowerNotificationObserver = NotificationCenter.default.addObserver(forName: .NSProcessInfoPowerStateDidChange, object: nil, queue: nil) { [weak self] _ in
             guard let self = self else {
                 return


### PR DESCRIPTION
We don't need to register if we don't want the feature enabled
Also there is a crash running atm with ios 15 https://twitter.com/steipete/status/1443506043733032962