### PR TITLE
[MT-875] fix import of Swift files from Obj-C in case of static library

### DIFF
--- a/tealium/collectors/autotracking/objc/UIViewController+TealiumTracker.m
+++ b/tealium/collectors/autotracking/objc/UIViewController+TealiumTracker.m
@@ -8,7 +8,11 @@
 
 #if TARGET_OS_IOS || TARGET_OS_TV
 #if COCOAPODS
+#if defined __has_include && __has_include(<TealiumSwift-Swift.h>)
+#import <TealiumSwift-Swift.h>
+#else
 #import <TealiumSwift/TealiumSwift-Swift.h>
+#endif
 #else
 #ifdef SWIFT_PACKAGE
 @import TealiumAutotracking;

--- a/tealium/core/objc/TealiumDelegateProxy+Swizzle.m
+++ b/tealium/core/objc/TealiumDelegateProxy+Swizzle.m
@@ -10,7 +10,11 @@
 #if TARGET_OS_IOS
 
 #if COCOAPODS
+#if defined __has_include && __has_include(<TealiumSwift-Swift.h>)
+#import <TealiumSwift-Swift.h>
+#else
 #import <TealiumSwift/TealiumSwift-Swift.h>
+#endif
 #else
 #ifdef SWIFT_PACKAGE
 @import TealiumCore;


### PR DESCRIPTION
Cocoapods without use_frameworks! compiles libraries as static libraries. When that's the case,
the generated swift header goes into <TealiumSwift-Swift.h> instead of <TealiumSwift/TealiumSwift-Swift.h>