### PR TITLE
[MT-903] fix issue with duplicated remote commands

### DIFF
--- a/support/tests/CoreMocks.swift
+++ b/support/tests/CoreMocks.swift
@@ -354,27 +354,19 @@ class MockLegacyUserDefaultsNoData: Storable {
     }
 }
 
-class MockUnarchiverConsent: Unarchivable {
-
-    var setClassCount = 0
+class MockUnarchiverConsent: ConsentUnarchiver {
     static var unarchiveCount = 0
-
-    func setClass(_ cls: AnyClass?, forClassName codedName: String) {
-        setClassCount += 1
-    }
-
-    static func unarchiveTopLevelObjectWithData(_ data: Data) throws -> Any? {
-        unarchiveCount += 1
+    
+    func decodeObject(fromData data: Data) throws -> Any? {
+        MockUnarchiverConsent.unarchiveCount += 1
         return MockConsentConfiguration()
     }
+    
 }
 
-class MockUnarchiverConsentNoData: Unarchivable {
+class MockUnarchiverConsentNoData: ConsentUnarchiver {
 
-    func setClass(_ cls: AnyClass?, forClassName codedName: String) {
-    }
-
-    static func unarchiveTopLevelObjectWithData(_ data: Data) throws -> Any? {
+    func decodeObject(fromData data: Data) throws -> Any? {
         nil
     }
 }

--- a/support/tests/test_tealium_core/MigratorTests.swift
+++ b/support/tests/test_tealium_core/MigratorTests.swift
@@ -52,18 +52,6 @@ class MigratorTests: XCTestCase {
         XCTAssertEqual(mockUserDefaultsConsent.removeCount, 0)
     }
 
-    func testExtractConsentPreferences_unarchiver_setClassMethodRun() {
-        migrator = Migrator(config: config, userDefaults: mockUserDefaultsConsent, unarchiver: mockUnarchiverConsent)
-        _ = migrator.extractConsentPreferences()
-        XCTAssertEqual(mockUnarchiverConsent.setClassCount, 1)
-    }
-
-    func testExtractConsentPreferences_unarchiver_setClassMethodNotRunWithNoData() {
-        migrator = Migrator(config: config, userDefaults: mockUserDefaultsConsentNoData, unarchiver: mockUnarchiverConsent)
-        _ = migrator.extractConsentPreferences()
-        XCTAssertEqual(mockUnarchiverConsent.setClassCount, 0)
-    }
-
     func testExtractConsentPreferences_unarchiver_unarchiveMethodRun() {
         MockUnarchiverConsent.unarchiveCount = 0
         migrator = Migrator(config: config, userDefaults: mockUserDefaultsConsent, unarchiver: mockUnarchiverConsent)

--- a/support/tests/test_tealium_remotecommands/RemoteCommandsManagerTests.swift
+++ b/support/tests/test_tealium_remotecommands/RemoteCommandsManagerTests.swift
@@ -163,6 +163,17 @@ class RemoteCommandsManagerTests: XCTestCase {
         XCTAssertEqual(1, mockDiskStorage.saveCount)
     }
     
+    func testAddRemoteCommandDoesntDeleteConfig() {
+        let fileName = "testName"
+        let command = RemoteCommand(commandId: "id", description: nil, type: .remote(url: "https://testName.com")) { response in
+
+        }
+        command.config = RemoteCommandConfig(config: ["fileName": fileName], mappings: [:], apiCommands: [:], commandName: fileName, commandURL: nil)
+        XCTAssertNotNil(command.config)
+        tealiumRemoteCommandsManager.add(command)
+        XCTAssertNotNil(command.config)
+    }
+    
     func testAddCommandsWithSameIdDoesNothing() {
         let currentJSONCommandCount = tealiumRemoteCommandsManager.jsonCommands.count
         let webviewCommandId = tealiumRemoteCommandsManager.webviewCommands.first!.commandId

--- a/tealium/core/Tealium.swift
+++ b/tealium/core/Tealium.swift
@@ -122,6 +122,10 @@ public class Tealium {
         #if os(iOS)
         TealiumDelegateProxy.removeContext(self.context)
         #endif
+        let disposeBag = self.disposeBag
+        TealiumQueues.secureMainThreadExecution { // disposeBag needs to be used from main thread
+            disposeBag.dispose() // avoid capturing self in deinit
+        }
     }
 
 }

--- a/tealium/core/storage/LegacyConsentConfiguration.swift
+++ b/tealium/core/storage/LegacyConsentConfiguration.swift
@@ -28,7 +28,7 @@ public class LegacyConsentConfiguration: NSObject, NSSecureCoding, ConsentConfig
     required public init?(coder: NSCoder) {
         self.consentStatus = coder.decodeInteger(forKey: MigrationKey.consentStatus)
         self.enableConsentLogging = coder.decodeBool(forKey: MigrationKey.consentLogging)
-        guard let categoriesArray = coder.decodeObject(of: NSArray.self, forKey: MigrationKey.consentCategories),
+        guard let categoriesArray = coder.decodeObject(of: [NSArray.self, NSString.self], forKey: MigrationKey.consentCategories),
               let categories = categoriesArray as? [String] else {
             self.consentCategories = TealiumConsentCategories.all.map { $0.rawValue }
             return

--- a/tealium/core/storage/LegacyStorageProtocols.swift
+++ b/tealium/core/storage/LegacyStorageProtocols.swift
@@ -15,9 +15,6 @@ public protocol Storable {
 
 extension UserDefaults: Storable { }
 
-public protocol Unarchivable {
-    func setClass(_ cls: AnyClass?, forClassName codedName: String)
-    static func unarchiveTopLevelObjectWithData(_ data: Data) throws -> Any?
+public protocol ConsentUnarchiver {
+    func decodeObject(fromData data: Data) throws -> Any?
 }
-
-extension NSKeyedUnarchiver: Unarchivable { }

--- a/tealium/core/utils/Migrator.swift
+++ b/tealium/core/utils/Migrator.swift
@@ -21,11 +21,27 @@ public protocol Migratable {
     func migratePersistent(dataLayer: DataLayerManagerProtocol)
 }
 
+struct LegacyConsentUnarchiver: ConsentUnarchiver {
+
+    func decodeObject(fromData data: Data) throws -> Any? {
+        if #available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *) {
+            let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+            unarchiver.setClass(LegacyConsentConfiguration.self, forClassName: MigrationKey.TEALConsentConfiguration)
+            unarchiver.requiresSecureCoding = true
+            let unarchived = unarchiver.decodeObject(of: [LegacyConsentConfiguration.self], forKey: NSKeyedArchiveRootObjectKey)
+            unarchiver.finishDecoding()
+            return unarchived
+        } else {
+            return nil
+        }
+    }
+}
+
 public struct Migrator: Migratable {
 
     var config: TealiumConfig
     var userDefaults: Storable? = UserDefaults.standard
-    var unarchiver: Unarchivable?
+    var unarchiver: ConsentUnarchiver? = LegacyConsentUnarchiver()
     var instance: String {
         "\(config.account).\(config.profile).\(config.environment)"
     }
@@ -34,7 +50,6 @@ public struct Migrator: Migratable {
         guard let consentConfiguration = retrieve(for: MigrationKey.consentConfiguration) as? Data else {
             return [String: Any]()
         }
-        set(type: LegacyConsentConfiguration.self, class: MigrationKey.TEALConsentConfiguration)
         guard let unarchivedConsentConfiguration = try? unarchive(data: consentConfiguration) as? ConsentConfigurable else {
             return [String: Any]()
         }
@@ -88,18 +103,10 @@ public struct Migrator: Migratable {
         userDefaults?.object(forKey: key)
     }
 
-    func set(type: AnyClass, class name: String) {
-        guard let unarchiver = unarchiver else {
-            NSKeyedUnarchiver.setClass(type, forClassName: name)
-            return
-        }
-        unarchiver.setClass(type, forClassName: name)
-    }
-
     func unarchive(data: Data) throws -> Any? {
         guard let unarchiver = unarchiver else {
-            return try NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data)
+                return nil
         }
-        return try type(of: unarchiver).self.unarchiveTopLevelObjectWithData(data)
+        return try? unarchiver.decodeObject(fromData: data)
     }
 }

--- a/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
@@ -196,7 +196,9 @@ public class RemoteCommandsManager: NSObject, RemoteCommandsManagerProtocol {
                 update(command: &remoteCommand, url: url, file: urlString.fileName)
                 jsonCommands.append(remoteCommand)
             }
-            remoteCommand.config = cachedConfig(for: urlString.fileName)
+            if let cached = cachedConfig(for: urlString.fileName) {
+                remoteCommand.config = cached
+            }
             remove(jsonCommand: urlString.fileName)
             update(command: &remoteCommand, url: url, file: urlString.fileName)
             refresh(remoteCommand, url: url, file: urlString.fileName)


### PR DESCRIPTION
deleting the config was causing the command not to be found
from the remove filter by fileName.