### PR TITLE
[MT-1115] Default commandName mapping for remote commands

### DIFF
--- a/builder/tealium-swift.xcodeproj/project.pbxproj
+++ b/builder/tealium-swift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		15046A0F28C8CBF000B0535E /* allEventsCommands.json in Resources */ = {isa = PBXBuildFile; fileRef = 15046A0E28C8CBF000B0535E /* allEventsCommands.json */; };
 		15062EEB270758EC00734060 /* large-event-data.json in Resources */ = {isa = PBXBuildFile; fileRef = D7187F1524768F5000CF0AB0 /* large-event-data.json */; };
 		15062EEC270758EC00734060 /* big-visitor.json in Resources */ = {isa = PBXBuildFile; fileRef = CF8FF2C524466FD90081C1A9 /* big-visitor.json */; };
 		151098E2273D5B150022AD66 /* TealiumAttribution.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D76FE19D2193093A00D73EC5 /* TealiumAttribution.framework */; };
@@ -2135,6 +2136,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		15046A0E28C8CBF000B0535E /* allEventsCommands.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = allEventsCommands.json; sourceTree = "<group>"; };
 		1516A2DE26EF7F26003DF8F2 /* TealiumAutotrackingUITests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TealiumAutotrackingUITests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1516A2EC26EF8193003DF8F2 /* TextContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextContent.swift; sourceTree = "<group>"; };
 		1519251E27219C68009BCACF /* SceneDelegateProxyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegateProxyTests.swift; sourceTree = "<group>"; };
@@ -3568,6 +3570,7 @@
 				CF3A590224DB462400A4851D /* badData.json */,
 				CF3A590324DB462400A4851D /* noMappingsKey.json */,
 				CF3A590424DB462400A4851D /* objectMappings.json */,
+				15046A0E28C8CBF000B0535E /* allEventsCommands.json */,
 			);
 			path = stubs;
 			sourceTree = "<group>";
@@ -5729,6 +5732,7 @@
 				CF3A590A24DB462500A4851D /* objectMappings.json in Resources */,
 				CF3A590624DB462500A4851D /* exampleNoConfig.json in Resources */,
 				CF3A590724DB462500A4851D /* example.json in Resources */,
+				15046A0F28C8CBF000B0535E /* allEventsCommands.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/support/tests/test_tealium_remotecommands/RemoteCommandsManagerTests.swift
+++ b/support/tests/test_tealium_remotecommands/RemoteCommandsManagerTests.swift
@@ -416,7 +416,7 @@ class RemoteCommandsManagerTests: XCTestCase {
 
     func testGetPayloadDataWithoutPayload() {
         let data: [String: Any] = [
-            "someKey": "someValye",
+            "someKey": "someValue",
             TealiumDataKey.eventType: TealiumTrackType.event.description
         ]
         let payload = tealiumRemoteCommandsManager.getPayloadData(data: data)

--- a/support/tests/test_tealium_remotecommands/RemoteCommandsManagerTests.swift
+++ b/support/tests/test_tealium_remotecommands/RemoteCommandsManagerTests.swift
@@ -403,6 +403,26 @@ class RemoteCommandsManagerTests: XCTestCase {
         }
     }
 
+    func testGetPayaloadDataWithPayload() {
+        let innerData = ["someKey": "anything"]
+        let data: [String: Any] = [
+            RemoteCommandsKey.payload: innerData,
+            TealiumDataKey.eventType: TealiumTrackType.event.description
+        ]
+        let payload = tealiumRemoteCommandsManager.getPayloadData(data: data)
+        XCTAssertTrue(payload.contains { $0.0 == "someKey"})
+        XCTAssertTrue(payload.contains { $0.0 == TealiumDataKey.eventType})
+    }
+
+    func testGetPayloadDataWithoutPayload() {
+        let data: [String: Any] = [
+            "someKey": "someValye",
+            TealiumDataKey.eventType: TealiumTrackType.event.description
+        ]
+        let payload = tealiumRemoteCommandsManager.getPayloadData(data: data)
+        XCTAssertEqual(payload as? [String: String], data as? [String: String])
+    }
+
 }
 
 extension RemoteCommandsManagerTests: ModuleDelegate {

--- a/support/tests/test_tealium_remotecommands/RemoteCommandsModuleTests.swift
+++ b/support/tests/test_tealium_remotecommands/RemoteCommandsModuleTests.swift
@@ -132,9 +132,9 @@ class RemoteCommandsModuleTests: XCTestCase {
     }
     
     func testTealiumEventType() {
-        let request = TealiumRemoteAPIRequest(trackRequest: TealiumTrackRequest(data: ["test": "data"]))
+        let request = TealiumRemoteAPIRequest(trackRequest: TealiumEvent("SomeEvent", dataLayer: ["test": "data"]).trackRequest)
         XCTAssertNil(request.trackRequest.trackDictionary["call_type"])
-        XCTAssertEqual(request.trackRequest.trackDictionary[TealiumDataKey.eventType] as! String, "remote_api")
+        XCTAssertEqual(request.trackRequest.trackDictionary[TealiumDataKey.eventType] as! String, "event", "remote_api is just sent instead of link in tagmanagement")
     }
 
 }

--- a/support/tests/test_tealium_remotecommands/TealiumRemoteCommandTests.swift
+++ b/support/tests/test_tealium_remotecommands/TealiumRemoteCommandTests.swift
@@ -261,6 +261,56 @@ class TealiumRemoteCommandTests: XCTestCase {
         XCTAssertNil(mapped?["config"])
     }
 
+    func testExtractCommandNameFromEvent() {
+        let noConfig = TestTealiumHelper.loadStub(from: "allEventsCommands", type(of: self))
+        let rcConfig = try! JSONDecoder().decode(RemoteCommandConfig.self, from: noConfig)
+        let trackData = [
+            TealiumDataKey.event: "launch"
+        ]
+        let commandName = remoteCommand.extractCommandName(trackData: trackData,
+                                         commandNames: rcConfig.apiCommands!)
+        XCTAssertNotNil(commandName)
+        XCTAssertEqual(commandName, "initialize")
+    }
+
+    func testExtractCommandNameFromAllEvents() {
+        let noConfig = TestTealiumHelper.loadStub(from: "allEventsCommands", type(of: self))
+        let rcConfig = try! JSONDecoder().decode(RemoteCommandConfig.self, from: noConfig)
+        let trackData = [
+            TealiumDataKey.event: "someOtherEvent",
+            TealiumDataKey.eventType: TealiumTrackType.event.description
+        ]
+        let commandName = remoteCommand.extractCommandName(trackData: trackData,
+                                         commandNames: rcConfig.apiCommands!)
+        XCTAssertNotNil(commandName)
+        XCTAssertEqual(commandName, "logevent")
+    }
+
+    func testExtractCommandNameFromAllViews() {
+        let noConfig = TestTealiumHelper.loadStub(from: "allEventsCommands", type(of: self))
+        let rcConfig = try! JSONDecoder().decode(RemoteCommandConfig.self, from: noConfig)
+        let trackData = [
+            TealiumDataKey.event: "someOtherEvent",
+            TealiumDataKey.eventType: TealiumTrackType.view.description
+        ]
+        let commandName = remoteCommand.extractCommandName(trackData: trackData,
+                                         commandNames: rcConfig.apiCommands!)
+        XCTAssertNotNil(commandName)
+        XCTAssertEqual(commandName, "logview")
+    }
+
+    func testExtractCommandNameNil() {
+        let noConfig = TestTealiumHelper.loadStub(from: "exampleNoConfig", type(of: self))
+        let rcConfig = try! JSONDecoder().decode(RemoteCommandConfig.self, from: noConfig)
+        let trackData = [
+            TealiumDataKey.event: "missingEvent",
+            TealiumDataKey.eventType: TealiumTrackType.event.description
+        ]
+        let commandName = remoteCommand.extractCommandName(trackData: trackData,
+                                         commandNames: rcConfig.apiCommands!)
+        XCTAssertNil(commandName)
+    }
+
 }
 
 extension TealiumRemoteCommandTests: ModuleDelegate {

--- a/support/tests/test_tealium_remotecommands/TealiumRemoteCommandTests.swift
+++ b/support/tests/test_tealium_remotecommands/TealiumRemoteCommandTests.swift
@@ -264,22 +264,17 @@ class TealiumRemoteCommandTests: XCTestCase {
     func testExtractCommandNameFromEvent() {
         let noConfig = TestTealiumHelper.loadStub(from: "allEventsCommands", type(of: self))
         let rcConfig = try! JSONDecoder().decode(RemoteCommandConfig.self, from: noConfig)
-        let trackData = [
-            TealiumDataKey.event: "launch"
-        ]
+        let trackData = TealiumEvent("launch").trackRequest.trackDictionary
         let commandName = remoteCommand.extractCommandName(trackData: trackData,
                                          commandNames: rcConfig.apiCommands!)
         XCTAssertNotNil(commandName)
-        XCTAssertEqual(commandName, "initialize")
+        XCTAssertEqual(commandName, "initialize,logevent")
     }
 
     func testExtractCommandNameFromAllEvents() {
         let noConfig = TestTealiumHelper.loadStub(from: "allEventsCommands", type(of: self))
         let rcConfig = try! JSONDecoder().decode(RemoteCommandConfig.self, from: noConfig)
-        let trackData = [
-            TealiumDataKey.event: "someOtherEvent",
-            TealiumDataKey.eventType: TealiumTrackType.event.description
-        ]
+        let trackData = TealiumEvent("someOtherEvent").trackRequest.trackDictionary
         let commandName = remoteCommand.extractCommandName(trackData: trackData,
                                          commandNames: rcConfig.apiCommands!)
         XCTAssertNotNil(commandName)
@@ -289,10 +284,7 @@ class TealiumRemoteCommandTests: XCTestCase {
     func testExtractCommandNameFromAllViews() {
         let noConfig = TestTealiumHelper.loadStub(from: "allEventsCommands", type(of: self))
         let rcConfig = try! JSONDecoder().decode(RemoteCommandConfig.self, from: noConfig)
-        let trackData = [
-            TealiumDataKey.event: "someOtherEvent",
-            TealiumDataKey.eventType: TealiumTrackType.view.description
-        ]
+        let trackData = TealiumView("someOtherEvent").trackRequest.trackDictionary
         let commandName = remoteCommand.extractCommandName(trackData: trackData,
                                          commandNames: rcConfig.apiCommands!)
         XCTAssertNotNil(commandName)
@@ -302,10 +294,7 @@ class TealiumRemoteCommandTests: XCTestCase {
     func testExtractCommandNameNil() {
         let noConfig = TestTealiumHelper.loadStub(from: "exampleNoConfig", type(of: self))
         let rcConfig = try! JSONDecoder().decode(RemoteCommandConfig.self, from: noConfig)
-        let trackData = [
-            TealiumDataKey.event: "missingEvent",
-            TealiumDataKey.eventType: TealiumTrackType.event.description
-        ]
+        let trackData = TealiumEvent("missingEvent").trackRequest.trackDictionary
         let commandName = remoteCommand.extractCommandName(trackData: trackData,
                                          commandNames: rcConfig.apiCommands!)
         XCTAssertNil(commandName)

--- a/support/tests/test_tealium_remotecommands/stubs/allEventsCommands.json
+++ b/support/tests/test_tealium_remotecommands/stubs/allEventsCommands.json
@@ -1,0 +1,11 @@
+{
+    "config": {
+    },
+    "mappings": {
+    },
+    "commands": {
+        "launch": "initialize",
+        "all_events": "logevent",
+        "all_views": "logview"
+    }
+}

--- a/tealium/collectors/media/MediaDispatch.swift
+++ b/tealium/collectors/media/MediaDispatch.swift
@@ -24,15 +24,21 @@ public struct TealiumMediaEvent: MediaDispatch {
     /// Consolidates all the data from the media session for a given track call
     /// - Returns; `[String: Any]`, flattened
     var data: [String: Any] {
-        var dictionary = [String: Any]()
+        trackRequest.trackDictionary
+    }
+
+    public var trackRequest: TealiumTrackRequest {
+        let eventName: String
         switch event {
         case .event(let name):
             if name.rawValue != StandardMediaEvent.milestone.rawValue {
                 parameters.milestone = nil
             }
-            dictionary[TealiumDataKey.event] = name.rawValue
-        case .custom(let name): dictionary[TealiumDataKey.event] = name
+            eventName = name.rawValue
+        case .custom(let name):
+            eventName = name
         }
+        var dictionary = [String: Any]()
         if let parameters = parameters.encoded?.flattened {
             dictionary += parameters.flattened
         }
@@ -40,11 +46,7 @@ public struct TealiumMediaEvent: MediaDispatch {
            let flattened = segment.dictionary?.flattened {
             dictionary.merge(flattened) { _, new in new }
         }
-        return dictionary
-    }
-
-    public var trackRequest: TealiumTrackRequest {
-        TealiumTrackRequest(data: self.data)
+        return TealiumEvent(eventName, dataLayer: dictionary).trackRequest
     }
 
 }

--- a/tealium/core/TealiumConstants.swift
+++ b/tealium/core/TealiumConstants.swift
@@ -166,7 +166,7 @@ public enum TealiumKey {
     static let traceIdQueryParam = "tealium_trace_id"
 }
 
-public enum TealiumTrackType {
+public enum TealiumTrackType: String {
     case view           // Whenever content is displayed to the user.
     case event
 

--- a/tealium/core/TealiumRequests.swift
+++ b/tealium/core/TealiumRequests.swift
@@ -63,9 +63,7 @@ public struct TealiumRemoteAPIRequest: TealiumRequest {
     public var trackRequest: TealiumTrackRequest
 
     public init(trackRequest: TealiumTrackRequest) {
-        var trackRequestData = trackRequest.trackDictionary
-        trackRequestData[TealiumDataKey.eventType] = TealiumKey.remoteAPIEventType
-        self.trackRequest = TealiumTrackRequest(data: trackRequestData)
+        self.trackRequest = trackRequest
     }
 
     public static func instanceTypeId() -> String {

--- a/tealium/core/consentmanager/ConsentManager.swift
+++ b/tealium/core/consentmanager/ConsentManager.swift
@@ -104,12 +104,7 @@ public class ConsentManager {
     func trackUserConsentPreferences() {
         // this track call must only be sent if "Log Consent Changes" is enabled and user has consented
         if consentLoggingEnabled, currentPolicy.shouldLogConsentStatus {
-            // call type must be set to override "link" or "view"
-            let trackData = [
-                TealiumDataKey.event: currentPolicy.consentTrackingEventName,
-                TealiumDataKey.eventType: currentPolicy.consentTrackingEventName
-            ]
-            delegate?.requestTrack(TealiumTrackRequest(data: trackData))
+            delegate?.requestTrack(TealiumEvent(currentPolicy.consentTrackingEventName).trackRequest)
         }
     }
 
@@ -118,7 +113,7 @@ public class ConsentManager {
     /// - Parameter consentData: `[String: Any]` containing the consent preferences
     func updateTIQCookie() {
         if currentPolicy.shouldUpdateConsentCookie {
-            // collect module ignores this hit
+            // collect module ignores this hit. Can't change the event type cause it's used to change the track call in the utag.js
             let trackData = [
                 TealiumDataKey.event: currentPolicy.updateConsentCookieEventName,
                 TealiumDataKey.eventType: currentPolicy.updateConsentCookieEventName

--- a/tealium/core/datalayer/TealiumTrace.swift
+++ b/tealium/core/datalayer/TealiumTrace.swift
@@ -58,7 +58,6 @@ public extension Tealium {
         }
         let dataLayer = [
             TealiumDataKey.killVisitorSessionEvent: TealiumKey.killVisitorSession,
-            TealiumDataKey.eventType: TealiumKey.killVisitorSession,
             TealiumDataKey.traceId: traceId
         ]
         let dispatch = TealiumEvent(TealiumKey.killVisitorSession,

--- a/tealium/dispatchers/remotecommands/RemoteCommand.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommand.swift
@@ -168,12 +168,12 @@ open class RemoteCommand: RemoteCommandProtocol {
     /// - Parameter self: `[String: String]` `mappings` key from JSON file definition
     /// - Returns: `[String: Any]` mapped key value pairs for specific remote command vendor
     public func mapPayload(_ payload: [String: Any], lookup: [String: String]) -> [String: Any] {
-        return lookup.reduce(into: [String: Any]()) { result, dictionary in
-            let values = dictionary.value.split(separator: ",")
+        return lookup.reduce(into: [String: Any]()) { result, tuple in
+            let values = tuple.value.split(separator: ",")
                 .map { $0.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines) }
-            values.forEach {
-                if payload[dictionary.key] != nil {
-                    result[String($0)] = payload[dictionary.key]
+            if let payload = payload[tuple.key] {
+                values.forEach {
+                    result[$0] = payload
                 }
             }
         }

--- a/tealium/dispatchers/remotecommands/RemoteCommand.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommand.swift
@@ -155,7 +155,10 @@ open class RemoteCommand: RemoteCommandProtocol {
         if let tealiumEvent = trackData[TealiumDataKey.event] as? String,
            let commandName = commandNames[tealiumEvent] {
             return commandName
-        } else if let eventType = trackData[TealiumDataKey.eventType] as? String {
+        } else if var eventType = trackData[TealiumDataKey.eventType] as? String {
+            if eventType != TealiumTrackType.view.rawValue {
+                eventType = TealiumTrackType.event.rawValue // Some events change this for utag.js
+            }
             return commandNames["all_\(eventType)s"]
         }
         return nil

--- a/tealium/dispatchers/remotecommands/RemoteCommand.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommand.swift
@@ -152,16 +152,24 @@ open class RemoteCommand: RemoteCommandProtocol {
     }
 
     func extractCommandName(trackData: [String: Any], commandNames: [String: String]) -> String? {
+        var commands = [String]()
         if let tealiumEvent = trackData[TealiumDataKey.event] as? String,
            let commandName = commandNames[tealiumEvent] {
-            return commandName
-        } else if var eventType = trackData[TealiumDataKey.eventType] as? String {
+            commands.append(commandName)
+        }
+        if var eventType = trackData[TealiumDataKey.eventType] as? String {
             if eventType != TealiumTrackType.view.rawValue {
                 eventType = TealiumTrackType.event.rawValue // Some events change this for utag.js
             }
-            return commandNames["all_\(eventType)s"]
+            if let commandName = commandNames["all_\(eventType)s"] {
+                commands.append(commandName)
+            }
         }
-        return nil
+        if commands.count > 0 {
+            return commands.joined(separator: ",")
+        } else {
+            return nil
+        }
     }
 
     /// Maps the payload recieved from a tracking call to the data specific to the third party

--- a/tealium/dispatchers/remotecommands/RemoteCommand.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommand.swift
@@ -140,8 +140,7 @@ open class RemoteCommand: RemoteCommandProtocol {
             completion?((.failure(TealiumRemoteCommandsError.commandsNotFound), nil))
             return nil
         }
-        guard let tealiumEvent = trackData[TealiumDataKey.event] as? String,
-              let commandName = commandNames[tealiumEvent] else {
+        guard let commandName = extractCommandName(trackData: trackData, commandNames: commandNames) else {
             completion?((.failure(TealiumRemoteCommandsError.commandNameNotFound), nil))
             return nil
         }
@@ -150,6 +149,16 @@ open class RemoteCommand: RemoteCommandProtocol {
             mapped.merge(config) { _, second in second }
         }
         return mapped
+    }
+
+    func extractCommandName(trackData: [String: Any], commandNames: [String: String]) -> String? {
+        if let tealiumEvent = trackData[TealiumDataKey.event] as? String,
+           let commandName = commandNames[tealiumEvent] {
+            return commandName
+        } else if let eventType = trackData[TealiumDataKey.eventType] as? String {
+            return commandNames["all_\(eventType)s"]
+        }
+        return nil
     }
 
     /// Maps the payload recieved from a tracking call to the data specific to the third party

--- a/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
@@ -250,7 +250,7 @@ public class RemoteCommandsManager: NSObject, RemoteCommandsManagerProtocol {
             }
         }
     }
-    
+
     func getPayloadData(data: [String: Any]) -> [String: Any] {
         guard var payload = data[RemoteCommandsKey.payload] as? [String: Any] else {
             return data

--- a/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
@@ -244,14 +244,22 @@ public class RemoteCommandsManager: NSObject, RemoteCommandsManagerProtocol {
                 guard let config = command.config else {
                     return
                 }
-                guard let payload = data[RemoteCommandsKey.payload] as? [String: Any] else {
-                    command.complete(with: data, config: config, completion: completion)
-                    return
-                }
-                command.complete(with: payload, config: config, completion: completion)
+                command.complete(with: getPayloadData(data: data),
+                                 config: config,
+                                 completion: completion)
             }
         }
-
+    }
+    
+    func getPayloadData(data: [String: Any]) -> [String: Any] {
+        guard var payload = data[RemoteCommandsKey.payload] as? [String: Any] else {
+            return data
+        }
+        let key = TealiumDataKey.eventType
+        if let eventType = data[key] {
+            payload += [key: eventType]
+        }
+        return payload
     }
 
     /// Trigger an associated remote command from a url request.

--- a/tealium/dispatchers/tagmanagement/TagManagementModule.swift
+++ b/tealium/dispatchers/tagmanagement/TagManagementModule.swift
@@ -148,7 +148,7 @@ public class TagManagementModule: Dispatcher {
             let newRequest = TealiumBatchTrackRequest(trackRequests: track.trackRequests.map { prepareForDispatch($0) })
             self.dispatchTrack(newRequest, completion: completion)
         case let track as TealiumRemoteAPIRequest:
-            self.dispatchTrack(prepareForDispatch(track.trackRequest), completion: completion)
+            self.dispatchTrack(prepareForDispatch(track.trackRequest, overrideEventType: TealiumKey.remoteAPIEventType), completion: completion)
             return
         case let command as TealiumRemoteCommandRequestResponse:
             if var jsCommand = command.data[TealiumKey.jsCommand] as? String {
@@ -212,9 +212,12 @@ public class TagManagementModule: Dispatcher {
     ///
     /// - Parameter request: `TealiumTrackRequest` to be insepcted/modified
     /// - Returns: `TealiumTrackRequest`
-    func prepareForDispatch(_ request: TealiumTrackRequest) -> TealiumTrackRequest {
+    func prepareForDispatch(_ request: TealiumTrackRequest, overrideEventType: String? = nil) -> TealiumTrackRequest {
         var newTrack = request.trackDictionary
         newTrack[TealiumDataKey.dispatchService] = TagManagementKey.moduleName
+        if let newEventType = overrideEventType {
+            newTrack[TealiumDataKey.eventType] = newEventType
+        }
         return TealiumTrackRequest(data: newTrack)
     }
 


### PR DESCRIPTION
Make all_views and all_events map for each missing view/event in remote commands

Create some utility methods to make it more readable and more testable