### PR TITLE
Use contains predicate instead of exact match to evaluate autotracking views

### DIFF
--- a/builder/tealium-swift.xcodeproj/project.pbxproj
+++ b/builder/tealium-swift.xcodeproj/project.pbxproj
@@ -59,6 +59,9 @@
 		1535101A28EB032E009D9AB9 /* VisitorIdStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1535101928EB032E009D9AB9 /* VisitorIdStorageTests.swift */; };
 		1535101B28EB032E009D9AB9 /* VisitorIdStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1535101928EB032E009D9AB9 /* VisitorIdStorageTests.swift */; };
 		1535101C28EB032E009D9AB9 /* VisitorIdStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1535101928EB032E009D9AB9 /* VisitorIdStorageTests.swift */; };
+		1549A24129AE06340021817D /* XCUIApplication+AssertTextExists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1549A24029AE06340021817D /* XCUIApplication+AssertTextExists.swift */; };
+		1549A24229AE06340021817D /* XCUIApplication+AssertTextExists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1549A24029AE06340021817D /* XCUIApplication+AssertTextExists.swift */; };
+		1549A24329AE06340021817D /* XCUIApplication+AssertTextExists.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1549A24029AE06340021817D /* XCUIApplication+AssertTextExists.swift */; };
 		1555F58F26E62DDC00AFDC3D /* TealiumInstanceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1555F58E26E62DDC00AFDC3D /* TealiumInstanceManagerTests.swift */; };
 		1555F59026E62DDC00AFDC3D /* TealiumInstanceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1555F58E26E62DDC00AFDC3D /* TealiumInstanceManagerTests.swift */; };
 		1555F59126E62DDC00AFDC3D /* TealiumInstanceManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1555F58E26E62DDC00AFDC3D /* TealiumInstanceManagerTests.swift */; };
@@ -2191,6 +2194,7 @@
 		1535101928EB032E009D9AB9 /* VisitorIdStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitorIdStorageTests.swift; sourceTree = "<group>"; };
 		15372735279081B60080D563 /* StoreKitTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKitTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/StoreKitTest.framework; sourceTree = DEVELOPER_DIR; };
 		1537275127908B2D0080D563 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS15.2.sdk/System/Library/Frameworks/StoreKit.framework; sourceTree = DEVELOPER_DIR; };
+		1549A24029AE06340021817D /* XCUIApplication+AssertTextExists.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+AssertTextExists.swift"; sourceTree = "<group>"; };
 		1555F58E26E62DDC00AFDC3D /* TealiumInstanceManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TealiumInstanceManagerTests.swift; sourceTree = "<group>"; };
 		1555F5CA26E6692400AFDC3D /* TealiumAutotrackingTests-macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TealiumAutotrackingTests-macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1555F5CE26E6769E00AFDC3D /* MockInMemoryDataLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInMemoryDataLayer.swift; sourceTree = "<group>"; };
@@ -3057,6 +3061,7 @@
 				15D43D5B26F20A68004E52FE /* AutoTrackingTvOSUITests.swift */,
 				15F8E24C26F0B3F700C4F6A1 /* AutoTrackingMacOSUITests.swift */,
 				15D4AFD926EB9CE6004316D0 /* AutoTrackingIOSUITests.swift */,
+				1549A24029AE06340021817D /* XCUIApplication+AssertTextExists.swift */,
 			);
 			path = ui_tests;
 			sourceTree = "<group>";
@@ -6116,6 +6121,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1516A2E926EF7FF0003DF8F2 /* AutoTrackingIOSUITests.swift in Sources */,
+				1549A24129AE06340021817D /* XCUIApplication+AssertTextExists.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6196,6 +6202,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				15D43D5C26F20A68004E52FE /* AutoTrackingTvOSUITests.swift in Sources */,
+				1549A24329AE06340021817D /* XCUIApplication+AssertTextExists.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6243,6 +6250,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				15F8E24D26F0B3F700C4F6A1 /* AutoTrackingMacOSUITests.swift in Sources */,
+				1549A24229AE06340021817D /* XCUIApplication+AssertTextExists.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingIOSUITests.swift
+++ b/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingIOSUITests.swift
@@ -27,39 +27,31 @@ class AutoTrackingIOSUITests: XCTestCase {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launch()
-        var text = """
-            RootView0
-            
-            """
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "RootView0")
         app.buttons["Launch ViewController"].tap()
-        text += "ViewControllerWrapper\n"
-        text += "RealVC\n" // Did appear happens late
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "ViewControllerWrapper")
+        assertStaticTextExists(app: app, text: "RealVC") // Did appear happens late
         app.navigationBars.firstMatch.buttons.firstMatch.tap()
-        text += "RootView1\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "RootView1")
         app.buttons["Launch Second View"].tap()
-        text += "SecondView\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "SecondView")
         app.navigationBars.firstMatch.buttons.firstMatch.tap()
-        text += "RootView2\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "RootView2")
         app.buttons["Launch Third View"].tap()
-        text += "AutotrackingView\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "AutotrackingView")
         app.navigationBars.firstMatch.buttons.firstMatch.tap()
-        text += "RootView3\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "RootView3")
         app.buttons["Launch Default UIViewController"].tap()
-        text += "UI\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "UI")
         app.navigationBars.firstMatch.buttons.firstMatch.tap()
-        text += "RootView4\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "RootView4")
     }
     
     func assertStaticTextExists(app: XCUIApplication, text: String) {
-        XCTAssertTrue(app.staticTexts[text].waitForExistence(timeout: 5), "Can not find \(text.split(separator: "\n").last!)")
+        let predicate = NSPredicate(format: "value CONTAINS[c] %@", text)
+        XCTAssertTrue(app.staticTexts
+            .containing(predicate).firstMatch
+            .waitForExistence(timeout: 5),
+                      "Can not find \(text)")
     }
 }

--- a/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingIOSUITests.swift
+++ b/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingIOSUITests.swift
@@ -27,31 +27,23 @@ class AutoTrackingIOSUITests: XCTestCase {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launch()
-        assertStaticTextExists(app: app, text: "RootView0")
+        app.assertStaticTextExists(text: "RootView0")
         app.buttons["Launch ViewController"].tap()
-        assertStaticTextExists(app: app, text: "ViewControllerWrapper")
-        assertStaticTextExists(app: app, text: "RealVC") // Did appear happens late
+        app.assertStaticTextExists(text: "ViewControllerWrapper")
+        app.assertStaticTextExists(text: "RealVC") // Did appear happens late
         app.navigationBars.firstMatch.buttons.firstMatch.tap()
-        assertStaticTextExists(app: app, text: "RootView1")
+        app.assertStaticTextExists(text: "RootView1")
         app.buttons["Launch Second View"].tap()
-        assertStaticTextExists(app: app, text: "SecondView")
+        app.assertStaticTextExists(text: "SecondView")
         app.navigationBars.firstMatch.buttons.firstMatch.tap()
-        assertStaticTextExists(app: app, text: "RootView2")
+        app.assertStaticTextExists(text: "RootView2")
         app.buttons["Launch Third View"].tap()
-        assertStaticTextExists(app: app, text: "AutotrackingView")
+        app.assertStaticTextExists(text: "AutotrackingView")
         app.navigationBars.firstMatch.buttons.firstMatch.tap()
-        assertStaticTextExists(app: app, text: "RootView3")
+        app.assertStaticTextExists(text: "RootView3")
         app.buttons["Launch Default UIViewController"].tap()
-        assertStaticTextExists(app: app, text: "UI")
+        app.assertStaticTextExists(text: "UI")
         app.navigationBars.firstMatch.buttons.firstMatch.tap()
-        assertStaticTextExists(app: app, text: "RootView4")
-    }
-    
-    func assertStaticTextExists(app: XCUIApplication, text: String) {
-        let predicate = NSPredicate(format: "value CONTAINS[c] %@", text)
-        XCTAssertTrue(app.staticTexts
-            .containing(predicate).firstMatch
-            .waitForExistence(timeout: 5),
-                      "Can not find \(text)")
+        app.assertStaticTextExists(text: "RootView4")
     }
 }

--- a/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingMacOSUITests.swift
+++ b/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingMacOSUITests.swift
@@ -27,26 +27,22 @@ class AutoTrackingMacOSUITests: XCTestCase {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launch()
-        var text = """
-            RootView0
-            
-            """
-        assertStaticTextExists(app: app, text: text)
-        text += "SomeView\n"
+        assertStaticTextExists(app: app, text: "RootView0")
         app.buttons["Launch ViewController"].click()
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "SomeView")
         app.buttons["Launch Second View"].click()
-        text += "SecondView\n"
-        assertStaticTextExists(app: app, text: text)
-        text += "SomeView\n"
+        assertStaticTextExists(app: app, text: "SecondView")
         app.buttons["Launch ViewController"].click()
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "SomeView")
         app.buttons["Launch Third View"].click()
-        text += "AutotrackingView\n"
-        assertStaticTextExists(app: app, text: text)        
+        assertStaticTextExists(app: app, text: "AutotrackingView")
     }
     
     func assertStaticTextExists(app: XCUIApplication, text: String) {
-        XCTAssertTrue(app.staticTexts[text].waitForExistence(timeout: 5), "Can not find \(text.split(separator: "\n").last!)")
+        let predicate = NSPredicate(format: "value CONTAINS[c] %@", text) // don't know why label doesn't work here
+        XCTAssertTrue(app.staticTexts
+            .containing(predicate).firstMatch
+            .waitForExistence(timeout: 5),
+                      "Can not find \(text)")
     }
 }

--- a/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingMacOSUITests.swift
+++ b/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingMacOSUITests.swift
@@ -27,22 +27,14 @@ class AutoTrackingMacOSUITests: XCTestCase {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
         app.launch()
-        assertStaticTextExists(app: app, text: "RootView0")
+        app.assertStaticTextExists(text: "RootView0")
         app.buttons["Launch ViewController"].click()
-        assertStaticTextExists(app: app, text: "SomeView")
+        app.assertStaticTextExists(text: "SomeView")
         app.buttons["Launch Second View"].click()
-        assertStaticTextExists(app: app, text: "SecondView")
+        app.assertStaticTextExists(text: "SecondView")
         app.buttons["Launch ViewController"].click()
-        assertStaticTextExists(app: app, text: "SomeView")
+        app.assertStaticTextExists(text: "SomeView")
         app.buttons["Launch Third View"].click()
-        assertStaticTextExists(app: app, text: "AutotrackingView")
-    }
-    
-    func assertStaticTextExists(app: XCUIApplication, text: String) {
-        let predicate = NSPredicate(format: "value CONTAINS[c] %@", text) // don't know why label doesn't work here
-        XCTAssertTrue(app.staticTexts
-            .containing(predicate).firstMatch
-            .waitForExistence(timeout: 5),
-                      "Can not find \(text)")
+        app.assertStaticTextExists(text: "AutotrackingView")
     }
 }

--- a/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingTvOSUITests.swift
+++ b/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingTvOSUITests.swift
@@ -28,59 +28,32 @@ class AutoTrackingTvOSUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         let remote = XCUIRemote.shared
-        var text = findStartText(app:app)
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "RootView0")
         remote.press(.select)
-        text += "ViewControllerWrapper\n"
-        text += "RealVC\n" // Did appear happens late
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "ViewControllerWrapper")
+        assertStaticTextExists(app: app, text: "RealVC") // Did appear happens late
         remote.press(.menu)
-        text += "RootView1\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "RootView1")
         remote.press(.down)
         remote.press(.select)
-        text += "SecondView\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "SecondView")
         remote.press(.menu)
-        text += "RootView2\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "RootView2")
         remote.press(.down)
         remote.press(.select)
-        text += "AutotrackingView\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "AutotrackingView")
         remote.press(.menu)
-        text += "RootView3\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "RootView3")
         remote.press(.down)
         remote.press(.select)
-        text += "UI\n"
-        assertStaticTextExists(app: app, text: text)
+        assertStaticTextExists(app: app, text: "UI")
     }
-    // Sometimes UINavigationController is after RootView0
-    func findStartText(app: XCUIApplication) -> String {
-        let text = """
-            RootView0
-            UINavigationController
-            
-            """
-        if app.staticTexts[text].waitForExistence(timeout: 5) {
-            return text
-        }
-        let otherText = """
-            UINavigationController
-            RootView0
-            
-            """
-        if app.staticTexts[otherText].waitForExistence(timeout: 5) {
-            return otherText
-        }
-        return app.staticTexts
-            .containing(NSPredicate(format: "label CONTAINS 'RootView0'"))
-            .element(matching: .any, identifier: nil)
-            .label // Last attempt
-    }
-    
+
     func assertStaticTextExists(app: XCUIApplication, text: String) {
-        XCTAssertTrue(app.staticTexts[text].waitForExistence(timeout: 5), "Can not find \(text.split(separator: "\n").last!)")
+        let predicate = NSPredicate(format: "label CONTAINS[c] %@", text) // don't know why value doesn't work here
+        XCTAssertTrue(app.staticTexts
+            .containing(predicate).firstMatch
+            .waitForExistence(timeout: 5),
+                      "Can not find \(text)")
     }
 }

--- a/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingTvOSUITests.swift
+++ b/support/tests/test_tealium_autotracking/ui_tests/AutoTrackingTvOSUITests.swift
@@ -28,32 +28,24 @@ class AutoTrackingTvOSUITests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         let remote = XCUIRemote.shared
-        assertStaticTextExists(app: app, text: "RootView0")
+        app.assertStaticTextExists(text: "RootView0")
         remote.press(.select)
-        assertStaticTextExists(app: app, text: "ViewControllerWrapper")
-        assertStaticTextExists(app: app, text: "RealVC") // Did appear happens late
+        app.assertStaticTextExists(text: "ViewControllerWrapper")
+        app.assertStaticTextExists(text: "RealVC") // Did appear happens late
         remote.press(.menu)
-        assertStaticTextExists(app: app, text: "RootView1")
+        app.assertStaticTextExists(text: "RootView1")
         remote.press(.down)
         remote.press(.select)
-        assertStaticTextExists(app: app, text: "SecondView")
+        app.assertStaticTextExists(text: "SecondView")
         remote.press(.menu)
-        assertStaticTextExists(app: app, text: "RootView2")
+        app.assertStaticTextExists(text: "RootView2")
         remote.press(.down)
         remote.press(.select)
-        assertStaticTextExists(app: app, text: "AutotrackingView")
+        app.assertStaticTextExists(text: "AutotrackingView")
         remote.press(.menu)
-        assertStaticTextExists(app: app, text: "RootView3")
+        app.assertStaticTextExists(text: "RootView3")
         remote.press(.down)
         remote.press(.select)
-        assertStaticTextExists(app: app, text: "UI")
-    }
-
-    func assertStaticTextExists(app: XCUIApplication, text: String) {
-        let predicate = NSPredicate(format: "label CONTAINS[c] %@", text) // don't know why value doesn't work here
-        XCTAssertTrue(app.staticTexts
-            .containing(predicate).firstMatch
-            .waitForExistence(timeout: 5),
-                      "Can not find \(text)")
+        app.assertStaticTextExists(text: "UI")
     }
 }

--- a/support/tests/test_tealium_autotracking/ui_tests/XCUIApplication+AssertTextExists.swift
+++ b/support/tests/test_tealium_autotracking/ui_tests/XCUIApplication+AssertTextExists.swift
@@ -1,0 +1,22 @@
+//
+//  XCUIApplication+AssertTextExists.swift
+//  tealium-swift
+//
+//  Created by Enrico Zannini on 28/02/23.
+//  Copyright © 2023 Tealium, Inc. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+
+extension XCUIApplication {
+    
+    func assertStaticTextExists(text: String) {
+        let predicate = NSPredicate(format: "value CONTAINS[c] %@ || label CONTAINS[c] %@", text, text) // don't know why value works for macOS and label for iOS and tvOS
+        XCTAssertTrue(staticTexts
+            .containing(predicate).firstMatch
+            .waitForExistence(timeout: 5),
+                      "Can not find \(text)")
+    }
+}


### PR DESCRIPTION
This should make tests more reliable as in some cases SwiftUI tracks views in non predefined order. 
Also, exact match is limited in the amount of characters. The contains predicate solves this.