### PR TITLE
added didCreateTealiumTrackRequestNotification notification

### DIFF
--- a/tealium/core/ModulesManager.swift
+++ b/tealium/core/ModulesManager.swift
@@ -21,6 +21,9 @@ enum ModulesManagerLogMessages {
 }
 
 public class ModulesManager {
+    // notification which is sent right before sending data. Client can subscribe to know exact dictionary to be sent
+    public static let didCreateTealiumTrackRequestNotification = Notification.Name("didCreateTealiumTrackRequestNotification")
+    
     // must store a copy of the initial config to allow locally-overridden properties to take precedence over remote ones. These would otherwise be lost after the first update.
     var originalConfig: TealiumConfig
     var remotePublishSettingsRetriever: TealiumPublishSettingsRetrieverProtocol?
@@ -185,6 +188,9 @@ public class ModulesManager {
         }
         let requestData = gatherTrackData(for: request.trackDictionary)
         let newRequest = TealiumTrackRequest(data: requestData)
+        let notification = Notification(name: Self.didCreateTealiumTrackRequestNotification,
+                                        object: newRequest)
+        NotificationCenter.default.post(notification)
         dispatchManager?.processTrack(newRequest)
         cachedTrackData = newRequest.trackDictionary
     }


### PR DESCRIPTION
This is a new minor feature. Initial problem is that we need to track what JSON data sent to Tealium server to validate tasks by QA. But working with decoding network traffic by proxy is not a trivial task. It would be a lot easier to have a callback right on the client side which reports raw dictionary which is going to be sent.