### PR TITLE
Fix possible PrivacyInfo clashes with CocoaPods

### DIFF
--- a/samples/TealiumSwiftExample/Podfile.lock
+++ b/samples/TealiumSwiftExample/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - tealium-swift (2.12.0):
-    - tealium-swift/TealiumFull (= 2.12.0)
-  - tealium-swift/Collect (2.12.0):
+  - tealium-swift (2.12.2):
+    - tealium-swift/TealiumFull (= 2.12.2)
+  - tealium-swift/Collect (2.12.2):
     - tealium-swift/Core
-  - tealium-swift/Core (2.12.0)
-  - tealium-swift/Lifecycle (2.12.0):
+  - tealium-swift/Core (2.12.2)
+  - tealium-swift/Lifecycle (2.12.2):
     - tealium-swift/Core
-  - tealium-swift/TealiumFull (2.12.0)
-  - tealium-swift/VisitorService (2.12.0):
+  - tealium-swift/TealiumFull (2.12.2)
+  - tealium-swift/VisitorService (2.12.2):
     - tealium-swift/Core
 
 DEPENDENCIES:
@@ -22,8 +22,8 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  tealium-swift: 0a099d2dae91be76cf6aed9f69806797d09c1cb9
+  tealium-swift: 4b7e3dda42d7c1de6acb769abad9920346d17d43
 
 PODFILE CHECKSUM: e9decae1a597032f7b4e373adc4add77507a031d
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.15.2

--- a/support/tests/test_tealium_core/TealiumDelegateProxyTests.swift
+++ b/support/tests/test_tealium_core/TealiumDelegateProxyTests.swift
@@ -97,12 +97,9 @@ class TealiumDelegateProxyTests: XCTestCase {
     }
     
     func waitOnTealiumSerialQueue(_ block: @escaping () -> ()) {
-        let exp = expectation(description: "dispatch")
-        TealiumQueues.backgroundSerialQueue.async {
+        TealiumQueues.backgroundSerialQueue.sync {
             block()
-            exp.fulfill()
         }
-        waitForExpectations(timeout: 2, handler: nil)
     }
     
     func sendOpenUrlEvent(url: URL) {

--- a/support/tests/test_tealium_remotecommands/RemoteCommandResponseTests.swift
+++ b/support/tests/test_tealium_remotecommands/RemoteCommandResponseTests.swift
@@ -33,9 +33,9 @@ class RemoteCommandResponseTests: XCTestCase {
 
     }
 
-    func testInitWithBadURLStringReturnsNil() {
-        let unescapedURLString = "tealium://test?request={\"config\":{\"response_id\":\"123\"}, \"payload\":{\"hello\": \"world\"}}"
-        let response = RemoteCommandResponse(urlString: unescapedURLString)
+    func testInitWithEmptyURLStringReturnsNil() {
+        let emptyString = ""
+        let response = RemoteCommandResponse(urlString: emptyString)
         XCTAssertNil(response)
     }
 

--- a/support/tests/test_tealium_visitorservice/VisitorServiceRetrieverTests.swift
+++ b/support/tests/test_tealium_visitorservice/VisitorServiceRetrieverTests.swift
@@ -35,7 +35,9 @@ class VisitorServiceRetrieverTests: XCTestCase {
         visitorServiceRetriever.sendURLRequest(request) { _ in
             expect.fulfill()
         }
-        wait(for: [expect], timeout: 1.0)
+        TealiumQueues.backgroundSerialQueue.sync {
+            wait(for: [expect], timeout: 1.0)
+        }
     }
 
     func testSendURLRequest_FailureInvalidURL() {
@@ -48,7 +50,9 @@ class VisitorServiceRetrieverTests: XCTestCase {
             }
             expect.fulfill()
         }
-        wait(for: [expect], timeout: 1.0)
+        TealiumQueues.backgroundSerialQueue.sync {
+            wait(for: [expect], timeout: 1.0)
+        }
     }
 
     func testSendURLRequest_Non200Response() {
@@ -61,7 +65,9 @@ class VisitorServiceRetrieverTests: XCTestCase {
             }
             expect.fulfill()
         }
-        wait(for: [expect], timeout: 3.0)
+        TealiumQueues.backgroundSerialQueue.sync {
+            wait(for: [expect], timeout: 1.0)
+        }
     }
 
     func testSendURLRequest_CouldNotCreateSession() {
@@ -75,7 +81,9 @@ class VisitorServiceRetrieverTests: XCTestCase {
             }
             expect.fulfill()
         }
-        wait(for: [expect], timeout: 3.0)
+        TealiumQueues.backgroundSerialQueue.sync {
+            wait(for: [expect], timeout: 1.0)
+        }
     }
 
 }

--- a/tealium-swift.podspec
+++ b/tealium-swift.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.name         = "tealium-swift"
   s.module_name  = "TealiumSwift"
-  s.version      = "2.12.1"
+  s.version      = "2.12.2"
   s.summary      = "Tealium Swift Integration Library"
 
   # This description is used to generate tags and improve search results.
@@ -97,7 +97,8 @@ Pod::Spec.new do |s|
     full.tvos.exclude_files = "tealium/dispatchers/tagmanagement/*","tealium/dispatchers/remotecommands/*","tealium/collectors/attribution/*","tealium/scripts/*","tealium/collectors/location/*","tealium/collectors/autotracking/objc/include/*.{h,m}","tealium/core/objc/**/*"
     full.watchos.exclude_files = "tealium/dispatchers/tagmanagement/*","tealium/dispatchers/remotecommands/*","tealium/collectors/attribution/*","tealium/scripts/*","tealium/collectors/location/*","tealium/collectors/autotracking/**/*.{h,m}","tealium/core/objc/**/*"
     full.osx.exclude_files = "tealium/dispatchers/tagmanagement/*","tealium/dispatchers/remotecommands/*","tealium/collectors/attribution/*","tealium/scripts/*","tealium/collectors/location/*","tealium/collectors/autotracking/**/*.{h,m}","tealium/core/objc/**/*"
-    full.resources = "tealium/core/devicedata/device-names.json","tealium/core/PrivacyInfo.xcprivacy"
+    full.resources = "tealium/core/devicedata/device-names.json"
+    full.resource_bundles = { "TealiumSwift" => "tealium/core/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "Core" do |core|
@@ -106,7 +107,8 @@ Pod::Spec.new do |s|
     core.tvos.exclude_files = "tealium/core/objc/**/*"
     core.watchos.exclude_files = "tealium/core/objc/**/*"
     core.osx.exclude_files = "tealium/core/objc/**/*"
-    core.resources = "tealium/core/devicedata/device-names.json","tealium/core/PrivacyInfo.xcprivacy"
+    core.resources = "tealium/core/devicedata/device-names.json"
+    core.resource_bundles = { "TealiumSwift" => "tealium/core/PrivacyInfo.xcprivacy" }
   end
 
   s.subspec "Attribution" do |attribution|

--- a/tealium/core/TealiumConstants.swift
+++ b/tealium/core/TealiumConstants.swift
@@ -14,7 +14,7 @@ public enum Dispatchers {}
 
 public enum TealiumValue {
     public static let libraryName = "swift"
-    public static let libraryVersion = "2.12.1"
+    public static let libraryVersion = "2.12.2"
     // This is the current limit for performance reasons. May be increased in future
     public static let maxEventBatchSize = 10
     public static let defaultMinimumDiskSpace: Int32 = 20_000_000


### PR DESCRIPTION
Use resource_boundles instead of resources for privacy info to avoid possible clashes