### PR TITLE
Release 2.15.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           - TealiumAutotracking
     steps:
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - uses: actions/checkout@v2
@@ -58,7 +58,7 @@ jobs:
           - TealiumVisitorService
     steps:
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - uses: actions/checkout@v2
@@ -109,7 +109,7 @@ jobs:
       working-directory: ./samples/TealiumSwiftExample
     steps:
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - uses: actions/checkout@v2
@@ -132,7 +132,7 @@ jobs:
       working-directory: ./samples/TealiumSwiftExample
     steps:
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - uses: actions/checkout@v2
@@ -155,7 +155,7 @@ jobs:
       working-directory: ./samples/ConsentManagerDemo
     steps:
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - uses: actions/checkout@v2
@@ -178,7 +178,7 @@ jobs:
       working-directory: ./samples/VisitorServiceDemo
     steps:
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,10 @@ jobs:
             - TealiumTagManagementTests-iOS
             - TealiumVisitorServiceTests-iOS
             - TealiumMomentsAPITests-iOS
+            - TealiumTraceTests-iOS
     steps:
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - uses: actions/checkout@v2
@@ -71,7 +72,7 @@ jobs:
           - TealiumMomentsAPITests-macOS
     steps:
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - uses: actions/checkout@v2
@@ -100,7 +101,7 @@ jobs:
           - TealiumMomentsAPITests-tvOS
     steps:
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - uses: actions/checkout@v2
@@ -119,7 +120,7 @@ jobs:
         destination: ["platform=iOS Simulator,OS=17.5,name=iPhone 15 Pro"]
     steps:
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - uses: actions/checkout@v2
@@ -159,7 +160,7 @@ jobs:
         destination: ["platform=tvOS Simulator,name=Apple TV"]
     steps:
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.4.1
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
       - uses: actions/checkout@v2

--- a/builder/tealium-swift.xcodeproj/project.pbxproj
+++ b/builder/tealium-swift.xcodeproj/project.pbxproj
@@ -904,6 +904,7 @@
 		D7F2DF07233279B2000D0E0F /* TealiumDiskTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D719955F22B8E47D005BE543 /* TealiumDiskTests.swift */; };
 		D7F8D8E7246079F500796E12 /* ModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7596C9A2451D6E1003AB939 /* ModuleDelegate.swift */; };
 		D7FF987D24AD0B6F00E87A80 /* MockAttributionData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7F075A24770212003E23B9 /* MockAttributionData.swift */; };
+		ECF1B0732D11D25D002DB84E /* TealiumConfig+PublishSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF1B0722D11D25D002DB84E /* TealiumConfig+PublishSettings.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2780,6 +2781,7 @@
 		D7F2DF0F233279B2000D0E0F /* TealiumCoreTests-tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TealiumCoreTests-tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D7FE15A022E61080000ABF56 /* TealiumDispatchQueueExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TealiumDispatchQueueExtensions.swift; sourceTree = "<group>"; };
 		D7FF987B24ACBD1300E87A80 /* AutoTrackingExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoTrackingExtensions.swift; sourceTree = "<group>"; };
+		ECF1B0722D11D25D002DB84E /* TealiumConfig+PublishSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TealiumConfig+PublishSettings.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3796,6 +3798,7 @@
 				CF8B6894255DC5E10055D72E /* TimedEventScheduler.swift */,
 				15F573ED2721827E00194733 /* UIScene+TealiumDelegateGetter.swift */,
 				1563CD4C2B458FFD00A04015 /* PrivacyInfo.xcprivacy */,
+				ECF1B0722D11D25D002DB84E /* TealiumConfig+PublishSettings.swift */,
 			);
 			path = core;
 			sourceTree = "<group>";
@@ -6269,7 +6272,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 		15037B9F2982904400EB8175 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6288,7 +6291,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 		15831B6627441AC700C0E8FC /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6307,7 +6310,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 		15831B6727441B7900C0E8FC /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6326,7 +6329,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 		15831B6827441B9100C0E8FC /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6345,7 +6348,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n\n";
 		};
 		15831B6927441B9D00C0E8FC /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6364,7 +6367,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 		15831B6A27441BB700C0E8FC /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6383,7 +6386,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 		15831B6B27441BC400C0E8FC /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6402,7 +6405,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 		15831B6C27441C5700C0E8FC /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6421,7 +6424,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 		15831B6D27441C6300C0E8FC /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6440,7 +6443,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 		15831B6E27441C6E00C0E8FC /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6459,7 +6462,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 		48290E3C273426B4008906AD /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -6478,7 +6481,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\nswiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint --config \"$PROJECT_DIR\"/../.swiftlint.yml\nelse\n    echo \"warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions.\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -7042,6 +7045,7 @@
 				D70FC793244EF8ED004AD838 /* Collector.swift in Sources */,
 				CFB1ED89244F908D005CC6F1 /* DataLayer.swift in Sources */,
 				CF3C1AF32473231E00A4DEE9 /* ConsentPreferencesStorage.swift in Sources */,
+				ECF1B0732D11D25D002DB84E /* TealiumConfig+PublishSettings.swift in Sources */,
 				43DE52D26A133BFF85D1845F /* AnyDecodable.swift in Sources */,
 				1519E00626E2689C000C71B4 /* ToAnyObservable.swift in Sources */,
 				D70FC7AA244F2C3D004AD838 /* AppDataConstants.swift in Sources */,

--- a/samples/ConsentManagerDemo/Podfile.lock
+++ b/samples/ConsentManagerDemo/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - Eureka (5.3.1)
-  - tealium-swift (2.14.1):
-    - tealium-swift/TealiumFull (= 2.14.1)
-  - tealium-swift/TealiumFull (2.14.1)
+  - tealium-swift (2.15.0):
+    - tealium-swift/TealiumFull (= 2.15.0)
+  - tealium-swift/TealiumFull (2.15.0)
 
 DEPENDENCIES:
   - Eureka (~> 5.3)
@@ -18,7 +18,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Eureka: 859877ab1e85661b6b7e810015d430e937d9cc7d
-  tealium-swift: 42edbaa8abc2d4e972b36ec1ad34d665a745aa6c
+  tealium-swift: 3c6d8d7b3b72fb09460f08c303c46eca4dbd5b23
 
 PODFILE CHECKSUM: a08a1d1cef2344f90eb2215ef34bbdf985d4db40
 

--- a/samples/TealiumMediaExample/Podfile.lock
+++ b/samples/TealiumMediaExample/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - tealium-swift (2.14.1):
-    - tealium-swift/TealiumFull (= 2.14.1)
-  - tealium-swift/TealiumFull (2.14.1)
+  - tealium-swift (2.15.0):
+    - tealium-swift/TealiumFull (= 2.15.0)
+  - tealium-swift/TealiumFull (2.15.0)
 
 DEPENDENCIES:
   - tealium-swift (from `../../`)
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  tealium-swift: 42edbaa8abc2d4e972b36ec1ad34d665a745aa6c
+  tealium-swift: 3c6d8d7b3b72fb09460f08c303c46eca4dbd5b23
 
 PODFILE CHECKSUM: 9f7c4052f5026295b89589ca935de017625dcaf3
 

--- a/samples/TealiumSwiftExample/Podfile.lock
+++ b/samples/TealiumSwiftExample/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - tealium-swift (2.14.1):
-    - tealium-swift/TealiumFull (= 2.14.1)
-  - tealium-swift/Collect (2.14.1):
+  - tealium-swift (2.15.0):
+    - tealium-swift/TealiumFull (= 2.15.0)
+  - tealium-swift/Collect (2.15.0):
     - tealium-swift/Core
-  - tealium-swift/Core (2.14.1)
-  - tealium-swift/Lifecycle (2.14.1):
+  - tealium-swift/Core (2.15.0)
+  - tealium-swift/Lifecycle (2.15.0):
     - tealium-swift/Core
-  - tealium-swift/TealiumFull (2.14.1)
-  - tealium-swift/VisitorService (2.14.1):
+  - tealium-swift/TealiumFull (2.15.0)
+  - tealium-swift/VisitorService (2.15.0):
     - tealium-swift/Core
 
 DEPENDENCIES:
@@ -22,7 +22,7 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  tealium-swift: 42edbaa8abc2d4e972b36ec1ad34d665a745aa6c
+  tealium-swift: 3c6d8d7b3b72fb09460f08c303c46eca4dbd5b23
 
 PODFILE CHECKSUM: e9decae1a597032f7b4e373adc4add77507a031d
 

--- a/samples/VisitorServiceDemo/Podfile.lock
+++ b/samples/VisitorServiceDemo/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
   - SCLAlertView (0.8)
   - SwiftConfettiView (0.1.0)
-  - tealium-swift/Collect (2.14.1):
+  - tealium-swift/Collect (2.15.0):
     - tealium-swift/Core
-  - tealium-swift/Core (2.14.1)
-  - tealium-swift/Lifecycle (2.14.1):
+  - tealium-swift/Core (2.15.0)
+  - tealium-swift/Lifecycle (2.15.0):
     - tealium-swift/Core
-  - tealium-swift/Location (2.14.1):
+  - tealium-swift/Location (2.15.0):
     - tealium-swift/Core
-  - tealium-swift/TagManagement (2.14.1):
+  - tealium-swift/TagManagement (2.15.0):
     - tealium-swift/Core
-  - tealium-swift/VisitorService (2.14.1):
+  - tealium-swift/VisitorService (2.15.0):
     - tealium-swift/Core
 
 DEPENDENCIES:
@@ -35,7 +35,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   SCLAlertView: 6a77bb2edfc65e04dbe57725546cb4107a506b85
   SwiftConfettiView: 1bdbc2e6913b6b1c76d8070802b212508ad5c352
-  tealium-swift: 42edbaa8abc2d4e972b36ec1ad34d665a745aa6c
+  tealium-swift: 3c6d8d7b3b72fb09460f08c303c46eca4dbd5b23
 
 PODFILE CHECKSUM: 52313dad09b407d6fd495d1d95dcfb1ef5c54268
 

--- a/support/tests/test_tealium_location/TealiumLocationTests.swift
+++ b/support/tests/test_tealium_location/TealiumLocationTests.swift
@@ -32,12 +32,7 @@ class TealiumLocationTests: XCTestCase {
 
         self.locationManager = locationManager
         TealiumLocationTests.expectations = [XCTestExpectation]()
-        config = TealiumConfig(account: "tealiummobile", profile: "location", environment: "dev")
         locationModule = createModule(with: config)
-    }
-
-    override func tearDown() {
-        TealiumLocationTests.expectations = [XCTestExpectation]()
     }
 
     // MARK: Tealium Location Tests
@@ -823,140 +818,98 @@ class TealiumLocationTests: XCTestCase {
     }
 
     func testModuleCreatedGeofences() {
-        let expect = expectation(description: "Module created geofences")
         locationModule?.tealiumLocationManager = mockTealiumLocationManager
         _ = locationModule?.createdGeofences
-        TealiumQueues.mainQueue.async { [weak self] in
-            XCTAssertEqual(self?.mockTealiumLocationManager.createdGeofencesCallCount, 1)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 2.0)
+        XCTAssertEqual(self.mockTealiumLocationManager.createdGeofencesCallCount, 1)
     }
 
-    func testModuleLatestLocation() {
-        let expect = expectation(description: "Module latest location called")
+    func testModuleGetCreatedGeofences() {
+        locationModule?.tealiumLocationManager = mockTealiumLocationManager
+        _ = locationModule?.getCreatedGeofences(completion: { _ in })
+        XCTAssertEqual(self.mockTealiumLocationManager.createdGeofencesCallCount, 1)
+    }
+
+    func testModuleLastLocation() {
         locationModule?.tealiumLocationManager = mockTealiumLocationManager
         _ = locationModule?.lastLocation
-        TealiumQueues.mainQueue.async { [weak self] in
-            XCTAssertEqual(self?.mockTealiumLocationManager.lastLocationCallCount, 1)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 2.0)
+        XCTAssertEqual(self.mockTealiumLocationManager.lastLocationCallCount, 1)
+    }
+
+    func testModuleGetLastLocation() {
+        locationModule?.tealiumLocationManager = mockTealiumLocationManager
+        _ = locationModule?.getLastLocation(completion: { _ in })
+        XCTAssertEqual(self.mockTealiumLocationManager.lastLocationCallCount, 1)
     }
 
     func testModuleMonitoredGeofences() {
-        let expect = expectation(description: "Module latest location called")
         locationModule?.tealiumLocationManager = mockTealiumLocationManager
         _ = locationModule?.monitoredGeofences
-        TealiumQueues.mainQueue.async { [weak self] in
-            XCTAssertEqual(self?.mockTealiumLocationManager.monitoredGeofencesCallCount, 1)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 2.0)
+        XCTAssertEqual(self.mockTealiumLocationManager.monitoredGeofencesCallCount, 1)
+    }
+
+    func testModuleGetMonitoredGeofences() {
+        locationModule?.tealiumLocationManager = mockTealiumLocationManager
+        _ = locationModule?.getMonitoredGeofences(completion: { _ in })
+        XCTAssertEqual(self.mockTealiumLocationManager.monitoredGeofencesCallCount, 1)
     }
 
     func testModuleClearMonitoredGeofences() {
-        let expect = expectation(description: "Module latest location called")
         locationModule?.tealiumLocationManager = mockTealiumLocationManager
         locationModule?.clearMonitoredGeofences()
-        TealiumQueues.mainQueue.async { [weak self] in
-            XCTAssertEqual(self?.mockTealiumLocationManager.clearMonitoredGeofencesCallCount, 1)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 2.0)
+        XCTAssertEqual(self.mockTealiumLocationManager.clearMonitoredGeofencesCallCount, 1)
     }
 
     func testModuleDisable() {
-        let expect = expectation(description: "Module latest location called")
         locationModule?.tealiumLocationManager = mockTealiumLocationManager
         locationModule?.disable()
-        TealiumQueues.mainQueue.async { [weak self] in
-            XCTAssertEqual(self?.mockTealiumLocationManager.disableCallCount, 1)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 2.0)
+        XCTAssertEqual(self.mockTealiumLocationManager.disableCallCount, 1)
     }
 
     func testModuleRequestAuthorization() {
-        let expect = expectation(description: "Module latest location called")
         locationModule?.tealiumLocationManager = mockTealiumLocationManager
         locationModule?.requestAuthorization()
-        TealiumQueues.mainQueue.async { [weak self] in
-            XCTAssertEqual(self?.mockTealiumLocationManager.requestAuthorizationCallCount, 1)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 2.0)
+        XCTAssertEqual(self.mockTealiumLocationManager.requestAuthorizationCallCount, 1)
     }
 
     func testModuleRequestTemporaryFullAccuracyAuthorization() {
         if #available(iOS 14, *) {
-            let expect = expectation(description: "Module latest location called")
             let purpose = "Because I said so"
             locationModule?.tealiumLocationManager = mockTealiumLocationManager
             locationModule?.requestTemporaryFullAccuracyAuthorization(purposeKey: purpose)
-            TealiumQueues.mainQueue.async { [weak self] in
-                XCTAssertEqual(self?.mockTealiumLocationManager.requestTemporaryFullAccuracyAuthorizationCallCount, 1)
-                expect.fulfill()
-            }
-            wait(for: [expect], timeout: 2.0)
+            XCTAssertEqual(self.mockTealiumLocationManager.requestTemporaryFullAccuracyAuthorizationCallCount, 1)
         }
     }
 
     func testModuleSendGeofenceTrackingEvent() {
-        let expect = expectation(description: "Module latest location called")
         locationModule?.tealiumLocationManager = mockTealiumLocationManager
         locationModule?.sendGeofenceTrackingEvent(region: CLRegion(), triggeredTransition: "test")
-        TealiumQueues.mainQueue.async { [weak self] in
-            XCTAssertEqual(self?.mockTealiumLocationManager.sendGeofenceTrackingEventCallCount, 1)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 2.0)
+        XCTAssertEqual(self.mockTealiumLocationManager.sendGeofenceTrackingEventCallCount, 1)
     }
 
     func testModuleStartLocationUpdates() {
-        let expect = expectation(description: "Module latest location called")
         locationModule?.tealiumLocationManager = mockTealiumLocationManager
         locationModule?.startLocationUpdates()
-        TealiumQueues.mainQueue.async { [weak self] in
-            XCTAssertEqual(self?.mockTealiumLocationManager.startLocationUpdatesCallCount, 1)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 2.0)
+        XCTAssertEqual(self.mockTealiumLocationManager.startLocationUpdatesCallCount, 1)
     }
 
     func testModuleStartMonitoring() {
-        let expect = expectation(description: "Module latest location called")
         locationModule?.tealiumLocationManager = mockTealiumLocationManager
         let region = CLCircularRegion(center: CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0), radius: CLLocationDistance(100.0), identifier: "Good_Geofence")
         locationModule?.startMonitoring(geofences: [region])
-        TealiumQueues.mainQueue.async { [weak self] in
-            XCTAssertEqual(self?.mockTealiumLocationManager.startMonitoringCallCount, 1)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 2.0)
+        XCTAssertEqual(self.mockTealiumLocationManager.startMonitoringCallCount, 1)
     }
 
     func testModuleStopLocationUpdates() {
-        let expect = expectation(description: "Module latest location called")
         locationModule?.tealiumLocationManager = mockTealiumLocationManager
         locationModule?.stopLocationUpdates()
-        TealiumQueues.mainQueue.async { [weak self] in
-            XCTAssertEqual(self?.mockTealiumLocationManager.stopLocationUpdatesCallCount, 1)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 2.0)
+        XCTAssertEqual(self.mockTealiumLocationManager.stopLocationUpdatesCallCount, 1)
     }
 
     func testModuleStopMonitoring() {
-        let expect = expectation(description: "Module latest location called")
         locationModule?.tealiumLocationManager = mockTealiumLocationManager
         let region = CLCircularRegion(center: CLLocationCoordinate2D(latitude: 0.0, longitude: 0.0), radius: CLLocationDistance(100.0), identifier: "Good_Geofence")
         locationModule?.stopMonitoring(geofences: [region])
-        TealiumQueues.mainQueue.async { [weak self] in
-            XCTAssertEqual(self?.mockTealiumLocationManager.stopMonitoringCallCount, 1)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: 2.0)
+        XCTAssertEqual(self.mockTealiumLocationManager.stopMonitoringCallCount, 1)
     }
 
 }

--- a/support/tests/test_tealium_tagmanagement/WKWebViewIntegrationTests.swift
+++ b/support/tests/test_tealium_tagmanagement/WKWebViewIntegrationTests.swift
@@ -14,17 +14,15 @@ import XCTest
 
 class WKWebViewIntegrationTests: XCTestCase {
 
-    let tagManagementWKWebView: TagManagementWKWebView = TagManagementWKWebView(config: testTealiumConfig.copy, delegate: TagManagementModuleDelegate())
-    let testURL = TestTealiumHelper().newConfig().webviewURL
-    let userDefaults = UserDefaults(suiteName: #file)
-
-    var expect: XCTestExpectation!
-    var module: TagManagementModule!
     let config = TealiumConfig(account: "testAccount", profile: "testProfile", environment: "testEnv")
+    lazy var tagManagementWKWebView: TagManagementWKWebView = TagManagementWKWebView(config: config.copy, delegate: TagManagementModuleDelegate())
+    lazy var testURL = config.webviewURL
+    let userDefaults = UserDefaults(suiteName: #file)
+    var module: TagManagementModule!
     var mockTagmanagement: MockTagManagementWebView!
     static var processPool = WKProcessPool()
     static var wkConfig: WKWebViewConfiguration = {
-      let config = WKWebViewConfiguration()
+        let config = WKWebViewConfiguration()
         config.processPool = WKWebViewIntegrationTests.processPool
         config.allowsAirPlayForMediaPlayback = false
         return config
@@ -42,7 +40,7 @@ class WKWebViewIntegrationTests: XCTestCase {
     }
 
     func testEnableWebView() {
-        let expectation = self.expectation(description: "testEnableWebView")
+        let expectation = expectation(description: "testEnableWebView")
         tagManagementWKWebView.enable(webviewURL: testURL, delegates: nil, view: nil) { _, _ in
             XCTAssertNotNil(self.tagManagementWKWebView.webview, "Webview instance was unexpectedly nil")
             expectation.fulfill()
@@ -51,10 +49,9 @@ class WKWebViewIntegrationTests: XCTestCase {
     }
     
     func testEnableWebViewWithProcessPool() {
-        let config = self.config.copy
         config.webviewProcessPool = WKWebViewIntegrationTests.processPool
         let webview = TagManagementWKWebView(config: config, delegate: TagManagementModuleDelegate())
-        let expectation = self.expectation(description: "testEnableWebView")
+        let expectation = expectation(description: "testEnableWebView")
         webview.enable(webviewURL: testURL, delegates: nil, view: nil) { _, _ in
             DispatchQueue.main.async {
                 let originalAddress = Unmanaged.passUnretained(WKWebViewIntegrationTests.processPool).toOpaque()
@@ -67,7 +64,6 @@ class WKWebViewIntegrationTests: XCTestCase {
     }
     
     func testEnableWebViewWithoutProcessPool() {
-        let config = self.config.copy
         let webview = TagManagementWKWebView(config: config, delegate: TagManagementModuleDelegate())
         let expectation = self.expectation(description: "testEnableWebView")
         webview.enable(webviewURL: testURL, delegates: nil, view: nil) { _, _ in
@@ -82,7 +78,6 @@ class WKWebViewIntegrationTests: XCTestCase {
     }
     
     func testEnableWebViewWithConfig() {
-        let config = self.config.copy
         config.webviewConfig = WKWebViewIntegrationTests.wkConfig
         let webview = TagManagementWKWebView(config: config, delegate: TagManagementModuleDelegate())
         let expectation = self.expectation(description: "testEnableWebView")
@@ -101,7 +96,6 @@ class WKWebViewIntegrationTests: XCTestCase {
     }
     
     func testEnableWebViewWithoutConfig() {
-        let config = self.config.copy
         let webview = TagManagementWKWebView(config: config, delegate: TagManagementModuleDelegate())
         let expectation = self.expectation(description: "testEnableWebView")
         webview.enable(webviewURL: testURL, delegates: nil, view: nil) { _, _ in
@@ -168,7 +162,7 @@ class WKWebViewIntegrationTests: XCTestCase {
     }
 
     func testDispatchTrackCreatesTrackRequest() {
-        expect = expectation(description: "trackRequest")
+        let expectation = expectation(description: "trackRequest")
         let context = TestTealiumHelper.context(with: config)
         module = TagManagementModule(context: context, delegate: TagManagementModuleDelegate(), completion: { [weak self] _ in
             let track = TealiumTrackRequest(data: ["test_track": true])
@@ -178,16 +172,16 @@ class WKWebViewIntegrationTests: XCTestCase {
                     XCTFail("Unexpected error: \(error.localizedDescription)")
                 case .success(let success):
                     XCTAssertTrue(success)
-                    self?.expect.fulfill()
+                    expectation.fulfill()
                 }
             })
         })
         
-        wait(for: [expect], timeout: 5.0)
+        wait(for: [expectation], timeout: 5.0)
     }
 
     func testDispatchTrackCreatesBatchTrackRequest() {
-        expect = expectation(description: "batchTrackRequest")
+        let expectation = expectation(description: "batchTrackRequest")
         let context = TestTealiumHelper.context(with: config)
         module = TagManagementModule(context: context, delegate: TagManagementModuleDelegate(), completion: { [weak self] _ in
             let track = TealiumTrackRequest(data: ["test_track": true])
@@ -198,15 +192,15 @@ class WKWebViewIntegrationTests: XCTestCase {
                     XCTFail("Unexpected error: \(error.localizedDescription)")
                 case .success(let success):
                     XCTAssertTrue(success)
-                    self?.expect.fulfill()
+                    expectation.fulfill()
                 }
             })
         })
-        wait(for: [expect], timeout: 10.0)
+        wait(for: [expectation], timeout: 10.0)
     }
     
     func testModuleWithQueryParamProviderChangesUrl() {
-        expect = expectation(description: "Enable complete")
+        let expectation = expectation(description: "Enable complete")
         let config = self.config.copy
         config.collectors = [MockQueryParamsProvider.self]
         let tealium = Tealium(config: config)
@@ -215,9 +209,9 @@ class WKWebViewIntegrationTests: XCTestCase {
             for item in MockQueryParamsProvider.defaultItems {
                 XCTAssertTrue(URLComponents(url: self.module.tagManagement.url!, resolvingAgainstBaseURL: false)!.queryItems!.contains(item))
             }
-            self.expect.fulfill()
+            expectation.fulfill()
         })
-        waitForExpectations(timeout: 5)
+        wait(for: [expectation], timeout: 5.0)
     }
 
 }

--- a/support/tests/test_tealium_visitorservice/VisitorServiceModuleTests.swift
+++ b/support/tests/test_tealium_visitorservice/VisitorServiceModuleTests.swift
@@ -12,26 +12,17 @@ import XCTest
 
 class VisitorServiceModuleTests: XCTestCase {
 
-    var mockDiskStorage: MockTealiumDiskStorage!
-    var mockVisitorServiceManager = MockTealiumVisitorServiceManager()
-    var config: TealiumConfig!
-    var context: TealiumContext!
-
-    override func setUp() {
-        super.setUp()
-        config = TealiumConfig(account: "testAccount", profile: "testProfile", environment: "testEnv")
-        context = TestTealiumHelper.context(with: config)
-        mockDiskStorage = MockTealiumDiskStorage()
-    }
+    let mockDiskStorage = MockTealiumDiskStorage()
+    let mockVisitorServiceManager = MockTealiumVisitorServiceManager()
+    let config = TealiumConfig(account: "testAccount", profile: "testProfile", environment: "testEnv")
+    lazy var context = TestTealiumHelper.context(with: config)
 
     func testRequestVisitorProfileRun() {
         let expect = expectation(description: "testRequestVisitorProfileRunWhenFirstEventSentTrue")
         let module = VisitorServiceModule(context: context, delegate: self, diskStorage: mockDiskStorage, visitorServiceManager: mockVisitorServiceManager)
-        TealiumQueues.backgroundSerialQueue.async {
-            module.retrieveProfileDelayed(visitorId: self.mockVisitorServiceManager.currentVisitorId!) {
-                XCTAssertEqual(1, self.mockVisitorServiceManager.requestVisitorProfileCount)
-                expect.fulfill()
-            }
+        module.retrieveProfileDelayed(visitorId: self.mockVisitorServiceManager.currentVisitorId!) {
+            XCTAssertEqual(1, self.mockVisitorServiceManager.requestVisitorProfileCount)
+            expect.fulfill()
         }
         wait(for: [expect], timeout: 10.0)
     }
@@ -40,10 +31,8 @@ class VisitorServiceModuleTests: XCTestCase {
         let expect = expectation(description: "visitor profile not requested when visitor id is different")
         expect.isInverted = true
         let module = VisitorServiceModule(context: context, delegate: self, diskStorage: mockDiskStorage, visitorServiceManager: mockVisitorServiceManager)
-        TealiumQueues.backgroundSerialQueue.async {
-            module.retrieveProfileDelayed(visitorId: self.mockVisitorServiceManager.currentVisitorId! + "buster") {
-                expect.fulfill()
-            }
+        module.retrieveProfileDelayed(visitorId: self.mockVisitorServiceManager.currentVisitorId! + "buster") {
+            expect.fulfill()
         }
         wait(for: [expect], timeout: 5.0)
     }
@@ -51,14 +40,12 @@ class VisitorServiceModuleTests: XCTestCase {
     func testBatchTrackRetreiveProfileExecuted() {
         let expect = expectation(description: "testBatchTrackRetreiveProfileExecuted")
         let module = VisitorServiceModule(context: context, delegate: self, diskStorage: mockDiskStorage, visitorServiceManager: mockVisitorServiceManager)
-        TealiumQueues.backgroundSerialQueue.async {
-            let trackRequest = TealiumTrackRequest(data: ["hello": "world", "tealium_visitor_id": self.mockVisitorServiceManager.currentVisitorId!])
-            let batchTrackRequest = TealiumBatchTrackRequest(trackRequests: [trackRequest])
-            module.willTrack(request: batchTrackRequest)
-            TealiumQueues.backgroundSerialQueue.asyncAfter(deadline: .now() + 3.0) {
-                XCTAssertEqual(1, self.mockVisitorServiceManager.requestVisitorProfileCount)
-                expect.fulfill()
-            }
+        let trackRequest = TealiumTrackRequest(data: ["hello": "world", "tealium_visitor_id": self.mockVisitorServiceManager.currentVisitorId!])
+        let batchTrackRequest = TealiumBatchTrackRequest(trackRequests: [trackRequest])
+        module.willTrack(request: batchTrackRequest)
+        TealiumQueues.backgroundSerialQueue.asyncAfter(deadline: .now() + 3.0) {
+            XCTAssertEqual(1, self.mockVisitorServiceManager.requestVisitorProfileCount)
+            expect.fulfill()
         }
         wait(for: [expect], timeout: 12.0)
     }
@@ -66,16 +53,12 @@ class VisitorServiceModuleTests: XCTestCase {
     func testTrackRetreiveProfileExecuted() {
         let expect = expectation(description: "testTrackRetreiveProfileExecuted")
         let module = VisitorServiceModule(context: context, delegate: self, diskStorage: mockDiskStorage, visitorServiceManager: mockVisitorServiceManager)
-        TealiumQueues.backgroundSerialQueue.async {
             let trackRequest = TealiumTrackRequest(data: ["hello": "world", "tealium_visitor_id": self.mockVisitorServiceManager.currentVisitorId!])
             module.willTrack(request: trackRequest)
             TealiumQueues.backgroundSerialQueue.asyncAfter(deadline: .now() + 3.0) {
-                TealiumQueues.backgroundSerialQueue.async {
                     XCTAssertEqual(1, self.mockVisitorServiceManager.requestVisitorProfileCount)
                     expect.fulfill()
-                }
             }
-        }
         wait(for: [expect], timeout: 12)
     }
 

--- a/tealium-swift.podspec
+++ b/tealium-swift.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.name         = "tealium-swift"
   s.module_name  = "TealiumSwift"
-  s.version      = "2.14.1"
+  s.version      = "2.15.0"
   s.summary      = "Tealium Swift Integration Library"
 
   # This description is used to generate tags and improve search results.

--- a/tealium/collectors/visitorservice/VisitorServiceManager.swift
+++ b/tealium/collectors/visitorservice/VisitorServiceManager.swift
@@ -19,7 +19,7 @@ public enum VisitorServiceStatus: Int {
     case blocked = 1
 }
 
-public protocol VisitorServiceManagerProtocol {
+public protocol VisitorServiceManagerProtocol: AnyObject {
     var currentVisitorId: String? { get set }
     var cachedProfile: TealiumVisitorProfile? { get }
     var lastFetch: Date? { get }

--- a/tealium/core/Tealium.swift
+++ b/tealium/core/Tealium.swift
@@ -51,17 +51,11 @@ public class Tealium {
             self.zz_internal_modulesManager = modulesManager ?? ModulesManager(context)
         }
 
-        TealiumQueues.secureMainThreadExecution {
-            TealiumInstanceManager.shared.onOpenUrl.subscribe { [weak self] url in
-                self?.handleDeepLink(url)
-            }.toDisposeBag(self.disposeBag)
-        }
-
-        TealiumQueues.secureMainThreadExecution {
-            TealiumInstanceManager.shared.onOpenUrl.subscribe { [weak self] url in
-                self?.handleDeepLink(url)
-            }.toDisposeBag(self.disposeBag)
-        }
+       TealiumQueues.secureMainThreadExecution {
+           TealiumInstanceManager.shared.onOpenUrl.subscribe { [weak self] url in
+               self?.handleDeepLink(url)
+           }.toDisposeBag(self.disposeBag)
+       }
 
         TealiumInstanceManager.shared.addInstance(self, config: config)
     }

--- a/tealium/core/TealiumConfig+PublishSettings.swift
+++ b/tealium/core/TealiumConfig+PublishSettings.swift
@@ -1,0 +1,201 @@
+//
+//  TealiumConfig+PublishSettings.swift
+//  tealium-swift
+//
+//  Copyright © 2024 Tealium, Inc. All rights reserved.
+//
+
+// MARK: Publish Settings
+public extension TealiumConfig {
+
+    /// Whether or not remote publish settings should be used. Default `true`.
+    var shouldUseRemotePublishSettings: Bool {
+        get {
+            options[TealiumConfigKey.publishSettings] as? Bool ?? true
+        }
+
+        set {
+            options[TealiumConfigKey.publishSettings] = newValue
+        }
+    }
+
+    /// Overrides the publish settings URL. Default is https://tags.tiqcdn.com/utag/ACCOUNT/PROFILE/ENVIRONMENT/mobile.html
+    /// If overriding, you must provide the entire URL, not just the domain.
+    /// Usage: `config.publishSettingsURL = "https://mycompany.org/utag/ACCOUNT/PROFILE/ENVIRONMENT/mobile.html"`
+    /// Takes precendence over `publishSettingsProfile`
+    var publishSettingsURL: String? {
+        get {
+            options[TealiumConfigKey.publishSettingsURL] as? String
+        }
+
+        set {
+            options[TealiumConfigKey.publishSettingsURL] = newValue
+        }
+    }
+
+    /// Overrides the publish settings profile. Default is to use the profile set on the `TealiumConfig` object.
+    /// Use this if you need to load the publish settings from a central profile that is different to the profile you're sending data to.
+    /// Usage: `config.publishSettingsProfile = "myprofile"`
+    var publishSettingsProfile: String? {
+        get {
+            options[TealiumConfigKey.publishSettingsProfile] as? String
+        }
+
+        set {
+            options[TealiumConfigKey.publishSettingsProfile] = newValue
+        }
+    }
+
+    /// If `false`, the entire library is disabled, and no tracking calls are sent.
+    var isEnabled: Bool? {
+        get {
+            options[TealiumConfigKey.libraryEnabled] as? Bool
+        }
+
+        set {
+            options[TealiumConfigKey.libraryEnabled] = newValue
+        }
+    }
+
+    /// If `false`, the the tag management module is disabled and will not be used for dispatching events
+    var isTagManagementEnabled: Bool {
+        get {
+            options[TealiumConfigKey.tagManagementModuleName] as? Bool ?? true
+        }
+
+        set {
+            options[TealiumConfigKey.tagManagementModuleName] = newValue
+        }
+    }
+
+    /// If `false`, the the collect module is disabled and will not be used for dispatching events
+    var isCollectEnabled: Bool {
+        get {
+            options[TealiumConfigKey.collectModuleName] as? Bool ?? true
+        }
+
+        set {
+            options[TealiumConfigKey.collectModuleName] = newValue
+        }
+    }
+
+    /// If `true`, calls will only be sent if the device has sufficient battery levels (>20%).
+    var batterySaverEnabled: Bool? {
+        get {
+            options[TealiumConfigKey.batterySaver] as? Bool
+        }
+
+        set {
+            options[TealiumConfigKey.batterySaver] = newValue
+        }
+    }
+
+    /// How long the data persists in the app if no data has been sent back (`-1` = no dispatch expiration). Default value is `7` days.
+    var dispatchExpiration: Int? {
+        get {
+            options[TealiumConfigKey.batchExpirationDaysKey] as? Int
+        }
+
+        set {
+            options[TealiumConfigKey.batchExpirationDaysKey] = newValue
+        }
+    }
+
+    /// Enables (`true`) or disables (`false`) event batching. Default `false`
+    var batchingEnabled: Bool? {
+        get {
+            // batching requires disk storage
+            guard diskStorageEnabled == true else {
+                return false
+            }
+            return options[TealiumConfigKey.batchingEnabled] as? Bool
+        }
+
+        set {
+            options[TealiumConfigKey.batchingEnabled] = newValue
+        }
+    }
+
+    /// How many events should be batched together
+    /// If set to `1`, events will be sent individually
+    var batchSize: Int {
+        get {
+            options[TealiumConfigKey.batchSizeKey] as? Int ?? TealiumValue.maxEventBatchSize
+        }
+
+        set {
+            let size = newValue > TealiumValue.maxEventBatchSize ? TealiumValue.maxEventBatchSize : newValue
+            options[TealiumConfigKey.batchSizeKey] = size
+        }
+
+    }
+
+    /// The maximum amount of events that will be stored offline
+    /// Oldest events are deleted to make way for new events if this limit is reached
+    var dispatchQueueLimit: Int? {
+        get {
+            options[TealiumConfigKey.queueSizeKey] as? Int
+        }
+
+        set {
+            options[TealiumConfigKey.queueSizeKey] = newValue
+        }
+    }
+
+    /// Restricts event data transmission to wifi only
+    /// Data will be queued if on cellular connection
+    var wifiOnlySending: Bool? {
+        get {
+            options[TealiumConfigKey.wifiOnlyKey] as? Bool
+        }
+
+        set {
+            options[TealiumConfigKey.wifiOnlyKey] = newValue
+        }
+    }
+
+    /// Determines how often the publish settings should be fetched from the CDN
+    /// Usually set automatically by the response from the remote publish settings
+    var minutesBetweenRefresh: Double? {
+        get {
+            options[TealiumConfigKey.minutesBetweenRefresh] as? Double
+        }
+
+        set {
+            options[TealiumConfigKey.minutesBetweenRefresh] = newValue
+        }
+    }
+
+    /// Sets the expiry for the Consent Manager preferences.
+    var consentExpiry: (time: Int, unit: TimeUnit)? {
+        get {
+            options[TealiumConfigKey.consentExpiry] as? (Int, TimeUnit)
+        }
+
+        set {
+            options[TealiumConfigKey.consentExpiry] = newValue
+        }
+    }
+
+    /// Defines the consent expiration callback
+    var onConsentExpiration: (() -> Void)? {
+        get {
+            options[TealiumConfigKey.consentExpiryCallback] as? (() -> Void)
+        }
+
+        set {
+            options[TealiumConfigKey.consentExpiryCallback] = newValue
+        }
+    }
+
+    /// Allows the Consent Categories key to be overridden
+    var overrideConsentCategoriesKey: String? {
+        get {
+            options[TealiumConfigKey.overrideConsentCategoriesKey] as? String
+        }
+
+        set {
+            options[TealiumConfigKey.overrideConsentCategoriesKey] = newValue
+        }
+    }
+}

--- a/tealium/core/TealiumConfig.swift
+++ b/tealium/core/TealiumConfig.swift
@@ -259,6 +259,7 @@ extension TealiumConfig: Equatable, Hashable {
 
 }
 
+// MARK: Known Visitor ID
 public extension TealiumConfig {
 
     /// Sets a known visitor ID. Must be unique (i.e. UUID).
@@ -270,202 +271,6 @@ public extension TealiumConfig {
 
         set {
             options[TealiumConfigKey.visitorId] = newValue
-        }
-    }
-
-}
-
-// MARK: Publish Settings
-public extension TealiumConfig {
-
-    /// Whether or not remote publish settings should be used. Default `true`.
-    var shouldUseRemotePublishSettings: Bool {
-        get {
-            options[TealiumConfigKey.publishSettings] as? Bool ?? true
-        }
-
-        set {
-            options[TealiumConfigKey.publishSettings] = newValue
-        }
-    }
-
-    /// Overrides the publish settings URL. Default is https://tags.tiqcdn.com/utag/ACCOUNT/PROFILE/ENVIRONMENT/mobile.html
-    /// If overriding, you must provide the entire URL, not just the domain.
-    /// Usage: `config.publishSettingsURL = "https://mycompany.org/utag/ACCOUNT/PROFILE/ENVIRONMENT/mobile.html"`
-    /// Takes precendence over `publishSettingsProfile`
-    var publishSettingsURL: String? {
-        get {
-            options[TealiumConfigKey.publishSettingsURL] as? String
-        }
-
-        set {
-            options[TealiumConfigKey.publishSettingsURL] = newValue
-        }
-    }
-
-    /// Overrides the publish settings profile. Default is to use the profile set on the `TealiumConfig` object.
-    /// Use this if you need to load the publish settings from a central profile that is different to the profile you're sending data to.
-    /// Usage: `config.publishSettingsProfile = "myprofile"`
-    var publishSettingsProfile: String? {
-        get {
-            options[TealiumConfigKey.publishSettingsProfile] as? String
-        }
-
-        set {
-            options[TealiumConfigKey.publishSettingsProfile] = newValue
-        }
-    }
-
-    /// If `false`, the entire library is disabled, and no tracking calls are sent.
-    var isEnabled: Bool? {
-        get {
-            options[TealiumConfigKey.libraryEnabled] as? Bool
-        }
-
-        set {
-            options[TealiumConfigKey.libraryEnabled] = newValue
-        }
-    }
-
-    /// If `false`, the the tag management module is disabled and will not be used for dispatching events
-    var isTagManagementEnabled: Bool {
-        get {
-            options[TealiumConfigKey.tagManagementModuleName] as? Bool ?? true
-        }
-
-        set {
-            options[TealiumConfigKey.tagManagementModuleName] = newValue
-        }
-    }
-
-    /// If `false`, the the collect module is disabled and will not be used for dispatching events
-    var isCollectEnabled: Bool {
-        get {
-            options[TealiumConfigKey.collectModuleName] as? Bool ?? true
-        }
-
-        set {
-            options[TealiumConfigKey.collectModuleName] = newValue
-        }
-    }
-
-    /// If `true`, calls will only be sent if the device has sufficient battery levels (>20%).
-    var batterySaverEnabled: Bool? {
-        get {
-            options[TealiumConfigKey.batterySaver] as? Bool
-        }
-
-        set {
-            options[TealiumConfigKey.batterySaver] = newValue
-        }
-    }
-
-    /// How long the data persists in the app if no data has been sent back (`-1` = no dispatch expiration). Default value is `7` days.
-    var dispatchExpiration: Int? {
-        get {
-            options[TealiumConfigKey.batchExpirationDaysKey] as? Int
-        }
-
-        set {
-            options[TealiumConfigKey.batchExpirationDaysKey] = newValue
-        }
-    }
-
-    /// Enables (`true`) or disables (`false`) event batching. Default `false`
-    var batchingEnabled: Bool? {
-        get {
-            // batching requires disk storage
-            guard diskStorageEnabled == true else {
-                return false
-            }
-            return options[TealiumConfigKey.batchingEnabled] as? Bool
-        }
-
-        set {
-            options[TealiumConfigKey.batchingEnabled] = newValue
-        }
-    }
-
-    /// How many events should be batched together
-    /// If set to `1`, events will be sent individually
-    var batchSize: Int {
-        get {
-            options[TealiumConfigKey.batchSizeKey] as? Int ?? TealiumValue.maxEventBatchSize
-        }
-
-        set {
-            let size = newValue > TealiumValue.maxEventBatchSize ? TealiumValue.maxEventBatchSize : newValue
-            options[TealiumConfigKey.batchSizeKey] = size
-        }
-
-    }
-
-    /// The maximum amount of events that will be stored offline
-    /// Oldest events are deleted to make way for new events if this limit is reached
-    var dispatchQueueLimit: Int? {
-        get {
-            options[TealiumConfigKey.queueSizeKey] as? Int
-        }
-
-        set {
-            options[TealiumConfigKey.queueSizeKey] = newValue
-        }
-    }
-
-    /// Restricts event data transmission to wifi only
-    /// Data will be queued if on cellular connection
-    var wifiOnlySending: Bool? {
-        get {
-            options[TealiumConfigKey.wifiOnlyKey] as? Bool
-        }
-
-        set {
-            options[TealiumConfigKey.wifiOnlyKey] = newValue
-        }
-    }
-
-    /// Determines how often the publish settings should be fetched from the CDN
-    /// Usually set automatically by the response from the remote publish settings
-    var minutesBetweenRefresh: Double? {
-        get {
-            options[TealiumConfigKey.minutesBetweenRefresh] as? Double
-        }
-
-        set {
-            options[TealiumConfigKey.minutesBetweenRefresh] = newValue
-        }
-    }
-
-    /// Sets the expiry for the Consent Manager preferences.
-    var consentExpiry: (time: Int, unit: TimeUnit)? {
-        get {
-            options[TealiumConfigKey.consentExpiry] as? (Int, TimeUnit)
-        }
-
-        set {
-            options[TealiumConfigKey.consentExpiry] = newValue
-        }
-    }
-
-    /// Defines the consent expiration callback
-    var onConsentExpiration: (() -> Void)? {
-        get {
-            options[TealiumConfigKey.consentExpiryCallback] as? (() -> Void)
-        }
-
-        set {
-            options[TealiumConfigKey.consentExpiryCallback] = newValue
-        }
-    }
-
-    /// Allows the Consent Categories key to be overridden
-    var overrideConsentCategoriesKey: String? {
-        get {
-            options[TealiumConfigKey.overrideConsentCategoriesKey] as? String
-        }
-
-        set {
-            options[TealiumConfigKey.overrideConsentCategoriesKey] = newValue
         }
     }
 }
@@ -480,6 +285,16 @@ public extension TealiumConfig {
 
         set {
             options[TealiumConfigKey.deepLinkTrackingEnabled] = newValue
+        }
+    }
+
+    var sendDeepLinkEvent: Bool {
+        get {
+            options[TealiumConfigKey.sendDeepLinkEvent] as? Bool ?? false
+        }
+
+        set {
+            options[TealiumConfigKey.sendDeepLinkEvent] = newValue
         }
     }
 

--- a/tealium/core/TealiumConstants.swift
+++ b/tealium/core/TealiumConstants.swift
@@ -14,7 +14,7 @@ public enum Dispatchers {}
 
 public enum TealiumValue {
     public static let libraryName = "swift"
-    public static let libraryVersion = "2.14.1"
+    public static let libraryVersion = "2.15.0"
     // This is the current limit for performance reasons. May be increased in future
     public static let maxEventBatchSize = 10
     public static let defaultMinimumDiskSpace: Int32 = 20_000_000
@@ -135,6 +135,7 @@ public enum TealiumConfigKey {
     public static let dispatchers = "dispatchers"
     static let lifecycleAutotrackingEnabled = "enable_lifecycle_autotracking"
     static let deepLinkTrackingEnabled = "deep_link_tracking_enabled"
+    static let sendDeepLinkEvent = "send_deep_link_event"
     static let qrTraceEnabled = "qr_trace_enabled"
     static let shouldMigrate = "should_migrate_data"
     public static let enableBackgroundMedia = "enable_background_media_tracking"
@@ -165,6 +166,7 @@ public enum TealiumKey {
     static let killVisitorSession = "kill_visitor_session"
     static let leaveTraceQueryParam = "leave_trace"
     static let traceIdQueryParam = "tealium_trace_id"
+    static let deepLink = "deep_link"
 }
 
 public enum TealiumTrackType: String {

--- a/tealium/core/TealiumInstanceManager.swift
+++ b/tealium/core/TealiumInstanceManager.swift
@@ -61,5 +61,4 @@ public class TealiumInstanceManager {
     func didOpenUrl(_ url: URL) {
         _onOpenUrl.publish(url)
     }
-
 }

--- a/tealium/core/datalayer/TealiumTrace.swift
+++ b/tealium/core/datalayer/TealiumTrace.swift
@@ -109,6 +109,9 @@ public extension Tealium {
                     dataLayer["\(TealiumDataKey.deepLinkQueryPrefix)_\($0.name)"] = value
                 }
                 self.dataLayer.add(data: dataLayer, expiry: .session)
+                if self.zz_internal_modulesManager?.config.sendDeepLinkEvent == true {
+                    self.track(TealiumEvent(TealiumKey.deepLink, dataLayer: dataLayer))
+                }
             }
         }
     }

--- a/tealium/core/logger/TealiumLoggerExtensions.swift
+++ b/tealium/core/logger/TealiumLoggerExtensions.swift
@@ -37,5 +37,4 @@ public extension TealiumConfig {
             options[TealiumConfigKey.logLevel] = newValue
         }
     }
-
 }

--- a/tealium/dispatchers/remotecommands/RemoteCommand.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommand.swift
@@ -34,7 +34,7 @@ open class RemoteCommand: RemoteCommandProtocol {
     /// - Parameters:
     ///     - commandId: `String` identifier for command block.
     ///     - description: `String?` description of command.
-    ///     - urlSession: `URLSessionProtocol`
+    ///     - type: `RemoteCommandType` one of three types defining the RC config source that will be used to build vendor specific data
     ///     - completion: The completion block to run when this remote command is triggered.
     public init(commandId: String,
                 description: String?,

--- a/tealium/dispatchers/remotecommands/RemoteCommandsConstants.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommandsConstants.swift
@@ -12,9 +12,15 @@ import Foundation
 import TealiumCore
 #endif
 
+/// This enum defines how the RemoteCommand is configured by the user.
+///
+/// The configuration will be used for mapping events data into vendor specific data.
 public enum RemoteCommandType {
+    /// A RemoteCommand that is configured via TiQ tag in the webview. The tag handles the mapping for this type.
     case webview
+    /// A RemoteCommand that is configured via JSON file hosted remotely. The RemoteCommand module handles the mapping for this type using the JSON config.
     case remote(url: String)
+    /// A RemoteCommand that is configured via JSON file bundled in the user app. The RemoteCommand module handles the mapping for this type using the JSON config.
     case local(file: String, bundle: Bundle? = nil)
 }
 


### PR DESCRIPTION
[MT-1553] Generate optional deep link event when a deep link is tracked (#342)

* Generate optional deep link event when a deep link is tracked

* update setup-xcode version - set v1 (get rid of 'set-output' command warnings)

* return Collect import back in TealiumTraceTests

* move TealiumTraceTests to separate step

* fix minor code issues: doc comment and constant namespace

* refine the RemoteCommandType documentation

* refactor VisitorServiceModule initializers

* remove redundant(?) queueing and setUp method in VisitorServiceModuleTests

* refactor WKWebViewIntegrationTests

* refactor TealiumLocationTests, add tests for new methods

[MT-1553]: https://tealium.atlassian.net/browse/MT-1553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ