### PR TITLE
[MT-1762] Fix potential crash for resource retriever

### DIFF
--- a/support/tests/test_tealium_core/network/ResourceRefresherTests.swift
+++ b/support/tests/test_tealium_core/network/ResourceRefresherTests.swift
@@ -230,7 +230,16 @@ final class ResourceRefresherTests: XCTestCase {
             waitForExpectations(timeout: 1.0)
         }
     }
-    
+
+    func testRefreshDoesntCaptureSelfDuringRefresh() {
+        mockUrlSession.result = .success(withData: nil, statusCode: 408)
+        weak var weakRefresher = refresher
+        refresher.requestRefresh()
+        XCTAssertNotNil(weakRefresher)
+        refresher = getRefresher()
+        XCTAssertNil(weakRefresher)
+    }
+
     class RefresherDelegate: ResourceRefresherDelegate {
         typealias Resource = CustomObject
         @ToAnyObservable<TealiumReplaySubject<CustomObject>>(TealiumReplaySubject<CustomObject>())

--- a/tealium/core/publishsettings/TealiumPublishSettingsRetriever.swift
+++ b/tealium/core/publishsettings/TealiumPublishSettingsRetriever.swift
@@ -85,4 +85,9 @@ class TealiumPublishSettingsRetriever: TealiumPublishSettingsRetrieverProtocol, 
         refresher.setRefreshInterval(resource.minutesBetweenRefresh * 60)
         delegate?.didUpdate(resource)
     }
+
+    deinit {
+        resourceRefresher?.resourceRetriever.stop()
+        resourceRefresher?.resourceRetriever.urlSession?.finishTealiumTasksAndInvalidate()
+    }
 }

--- a/tealium/core/utils/network/ItemsProvider.swift
+++ b/tealium/core/utils/network/ItemsProvider.swift
@@ -49,7 +49,7 @@ open class ItemsProvider<Item: Codable & Equatable> {
     public init(id: String,
                 location: ItemsFileLocation,
                 bundle: Bundle,
-                urlSession: URLSessionProtocol = URLSession(configuration: .ephemeral),
+                urlSession: URLSessionProtocol? = nil,
                 diskStorage: TealiumDiskStorageProtocol,
                 logger: TealiumLoggerProtocol?) {
 
@@ -59,7 +59,7 @@ open class ItemsProvider<Item: Codable & Equatable> {
                   let url = URL(string: urlString) else {
                 return nil
             }
-            let resourceRetriever = ResourceRetriever<Resource>(urlSession: urlSession) { data, etag in
+            let resourceRetriever = ResourceRetriever<Resource>(urlSession: urlSession ?? URLSession(configuration: .ephemeral)) { data, etag in
                 guard let items = try? JSONDecoder().decode([Item].self, from: data) else {
                     return nil
                 }
@@ -135,6 +135,11 @@ open class ItemsProvider<Item: Codable & Equatable> {
                                            message: message, info: nil,
                                            logLevel: .debug, category: .general)
         logger?.log(logRequest)
+    }
+
+    deinit {
+        resourceRefresher?.resourceRetriever.stop()
+        resourceRefresher?.resourceRetriever.urlSession?.finishTealiumTasksAndInvalidate()
     }
 }
 

--- a/tealium/core/utils/network/ResourceRefresher.swift
+++ b/tealium/core/utils/network/ResourceRefresher.swift
@@ -84,7 +84,8 @@ public class ResourceRefresher<Resource: Codable & EtagResource> {
 
     private func refresh() {
         fetching = true
-        resourceRetriever.getResource(url: parameters.url, etag: lastEtag) { result in
+        resourceRetriever.getResource(url: parameters.url, etag: lastEtag) { [weak self] result in
+            guard let self else { return }
             switch result {
             case .success(let resource):
                 self.saveResource(resource)

--- a/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
@@ -202,6 +202,7 @@ public class RemoteCommandsManager: NSObject, RemoteCommandsManagerProtocol {
     }
 
     deinit {
+        resourceRetriever.stop()
         urlSession.finishTealiumTasksAndInvalidate()
     }
 }


### PR DESCRIPTION
Fix potential crash for resource retriever using URLSession after being invalidated

Make sure resource refresher deallocates without waiting for retriever to complete.
Additionally, provide a way to stop retriever, and call it from RemoteCommandsManager.
Add a missing invalidate in the settings retriever and ItemsProvider on deinit, to avoid urlSessions wasting resources after deinit.