### PR TITLE
[MT-1723] Remove == method for [String: Any] dictionary

### DIFF
--- a/support/tests/test_tealium_core/TealiumUtilsTests.swift
+++ b/support/tests/test_tealium_core/TealiumUtilsTests.swift
@@ -179,6 +179,19 @@ class TealiumUtilsTests: XCTestCase {
         }
     }
 
+    private struct Container: Equatable {
+        let dict: [String: Obj]
+    }
+    private struct Obj: Equatable {
+        let str: String
+    }
+    func testEquatableDictionary() {
+        let obj = Obj(str: "someValue")
+        let dict = ["someKey" : obj]
+        XCTAssertTrue(dict == dict) // Fails if custom `==` is implemented with NSDictionary.isEqual
+        let container = Container(dict: dict)
+        XCTAssertEqual(container, container) // Fails if custom `==` is implemented with NSDictionary.isEqual
+    }
 }
 
 func generateTestDict() -> [String: Any] {

--- a/support/tests/test_tealium_core/TealiumUtilsTests.swift
+++ b/support/tests/test_tealium_core/TealiumUtilsTests.swift
@@ -186,11 +186,12 @@ class TealiumUtilsTests: XCTestCase {
         let str: String
     }
     func testEquatableDictionary() {
+        // Fails if custom `==` is implemented on [String: Any] with NSDictionary.isEqual on iOS <= 17
         let obj = Obj(str: "someValue")
-        let dict = ["someKey" : obj]
-        XCTAssertTrue(dict == dict) // Fails if custom `==` is implemented with NSDictionary.isEqual
+        let dict = ["someKey": obj]
+        XCTAssertTrue(dict == dict)
         let container = Container(dict: dict)
-        XCTAssertEqual(container, container) // Fails if custom `==` is implemented with NSDictionary.isEqual
+        XCTAssertEqual(container, container)
     }
 }
 

--- a/support/tests/test_tealium_core/dispatch_manager/DispatchQueueTests.swift
+++ b/support/tests/test_tealium_core/dispatch_manager/DispatchQueueTests.swift
@@ -67,7 +67,7 @@ class DispatchQueueTests: XCTestCase {
         savedTrackData.forEach {
             let savedData = $0.trackDictionary
             let testData = track.trackDictionary
-            XCTAssertTrue(savedData == testData)
+            XCTAssertTrue(NSDictionary(dictionary: savedData).isEqual(to: testData))
         }
     }
 

--- a/support/tests/test_tealium_core/dispatch_manager/DispatchQueueTests.swift
+++ b/support/tests/test_tealium_core/dispatch_manager/DispatchQueueTests.swift
@@ -67,7 +67,7 @@ class DispatchQueueTests: XCTestCase {
         savedTrackData.forEach {
             let savedData = $0.trackDictionary
             let testData = track.trackDictionary
-            XCTAssertTrue(NSDictionary(dictionary: savedData).isEqual(to: testData))
+            XCTAssertTrue((savedData as NSDictionary).isEqual(to: testData))
         }
     }
 

--- a/tealium/core/TealiumRequests.swift
+++ b/tealium/core/TealiumRequests.swift
@@ -118,7 +118,7 @@ public struct TealiumTrackRequest: TealiumRequest, Codable, Comparable {
     }
 
     public static func == (lhs: TealiumTrackRequest, rhs: TealiumTrackRequest) -> Bool {
-        NSDictionary(dictionary: lhs.trackDictionary).isEqual(to: rhs.trackDictionary)
+        (lhs.trackDictionary as NSDictionary).isEqual(to: rhs.trackDictionary)
     }
 
     public var uuid: String {

--- a/tealium/core/TealiumRequests.swift
+++ b/tealium/core/TealiumRequests.swift
@@ -118,7 +118,7 @@ public struct TealiumTrackRequest: TealiumRequest, Codable, Comparable {
     }
 
     public static func == (lhs: TealiumTrackRequest, rhs: TealiumTrackRequest) -> Bool {
-        lhs.trackDictionary == rhs.trackDictionary
+        NSDictionary(dictionary: lhs.trackDictionary).isEqual(to: rhs.trackDictionary)
     }
 
     public var uuid: String {

--- a/tealium/core/datalayer/HostedDataLayerCache.swift
+++ b/tealium/core/datalayer/HostedDataLayerCache.swift
@@ -10,7 +10,7 @@ import Foundation
 struct HostedDataLayerCacheItem: Codable, Equatable {
     static func == (lhs: HostedDataLayerCacheItem, rhs: HostedDataLayerCacheItem) -> Bool {
         if let lhsData = lhs.data, let rhsData = rhs.data {
-            return lhs.id == rhs.id && NSDictionary(dictionary: lhsData).isEqual(to: rhsData)
+            return lhs.id == rhs.id && (lhsData as NSDictionary).isEqual(to: rhsData)
         } else {
             return lhs.id == rhs.id
         }

--- a/tealium/core/datalayer/HostedDataLayerCache.swift
+++ b/tealium/core/datalayer/HostedDataLayerCache.swift
@@ -10,7 +10,7 @@ import Foundation
 struct HostedDataLayerCacheItem: Codable, Equatable {
     static func == (lhs: HostedDataLayerCacheItem, rhs: HostedDataLayerCacheItem) -> Bool {
         if let lhsData = lhs.data, let rhsData = rhs.data {
-            return lhs.id == rhs.id && lhsData == rhsData
+            return lhs.id == rhs.id && NSDictionary(dictionary: lhsData).isEqual(to: rhsData)
         } else {
             return lhs.id == rhs.id
         }

--- a/tealium/core/utils/Dictionary+Tealium.swift
+++ b/tealium/core/utils/Dictionary+Tealium.swift
@@ -21,11 +21,6 @@ public func += <K, V>(left: inout [K: V], right: [K: V]) {
     }
 }
 
-/// Extend use of == to dictionaries.
-public func == (lhs: [String: Any], rhs: [String: Any] ) -> Bool {
-    NSDictionary(dictionary: lhs).isEqual(to: rhs)
-}
-
 public extension Dictionary where Key == String, Value == Any {
 
     var codable: AnyCodable {


### PR DESCRIPTION
This is done to remove potential conflicts with Equatable swift objects that can't be compared with NSDictionary.isEqual on iOS < 18 and would therefore erroneously fail the equality comparison.