### PR TITLE
[MT-1766] Consent logging improvements

### DIFF
--- a/support/tests/test_tealium_core/consent_manager/ConsentManagerModuleTests.swift
+++ b/support/tests/test_tealium_core/consent_manager/ConsentManagerModuleTests.swift
@@ -371,6 +371,25 @@ class ConsentManagerModuleTests: XCTestCase {
         XCTAssertNotNil(trackInfo["custom_consent_key"] as? String)
     }
 
+    func testGdprConsentPolicyReturnsPartialConsentIfCategoriesAreNilOrNotFull() {
+        let policyType = TealiumConsentPolicy.gdpr
+        var policy = ConsentPolicyFactory.create(policyType, preferences: UserConsentPreferences(consentStatus: .unknown, consentCategories: nil))
+        XCTAssertEqual(policy.consentTrackingEventName, "grant_partial_consent")
+        policy.preferences = UserConsentPreferences(consentStatus: .consented, consentCategories: [.affiliates])
+        XCTAssertEqual(policy.consentTrackingEventName, "grant_partial_consent")
+    }
+
+    func testGdprConsentPolicyReturnsFullConsentIfCategoriesAreFull() {
+        let policyType = TealiumConsentPolicy.gdpr
+        var policy = ConsentPolicyFactory.create(policyType, preferences: UserConsentPreferences(consentStatus: .consented, consentCategories: TealiumConsentCategories.all))
+        XCTAssertEqual(policy.consentTrackingEventName, "grant_full_consent")
+    }
+
+    func testGdprConsentPolicyReturnsDeclinedIfStatusNotConsented() {
+        let policyType = TealiumConsentPolicy.gdpr
+        var policy = ConsentPolicyFactory.create(policyType, preferences: UserConsentPreferences(consentStatus: .notConsented, consentCategories: TealiumConsentCategories.all))
+        XCTAssertEqual(policy.consentTrackingEventName, "decline_consent")
+    }
 }
 
 extension ConsentManagerModuleTests: ModuleDelegate {

--- a/support/tests/test_tealium_core/dispatch_manager/DispatchQueueTests.swift
+++ b/support/tests/test_tealium_core/dispatch_manager/DispatchQueueTests.swift
@@ -77,7 +77,7 @@ class DispatchQueueTests: XCTestCase {
         persistentQueue?.diskStorage.append(track, completion: nil)
         var data = persistentQueue?.diskStorage.retrieve(as: [TealiumTrackRequest].self)
         XCTAssertEqual(data!.count, 2)
-        persistentQueue?.clearQueue()
+        persistentQueue?.clearNonAuditEvents()
         XCTAssertEqual(persistentQueue?.currentEvents, 0)
         data = persistentQueue?.diskStorage.retrieve(as: [TealiumTrackRequest].self)
         XCTAssertEqual(data!.count, 0)

--- a/tealium/core/consentmanager/ConsentManager.swift
+++ b/tealium/core/consentmanager/ConsentManager.swift
@@ -103,7 +103,7 @@ public class ConsentManager {
     /// - Parameter preferences: `UserConsentPreferences?`
     func trackUserConsentPreferences() {
         // this track call must only be sent if "Log Consent Changes" is enabled and user has consented
-        if consentLoggingEnabled, currentPolicy.shouldLogConsentStatus {
+        if consentLoggingEnabled, currentPolicy.shouldLogConsentStatus, userConsentStatus != .unknown {
             delegate?.requestTrack(TealiumEvent(currentPolicy.consentTrackingEventName).trackRequest)
         }
     }
@@ -163,6 +163,5 @@ public extension ConsentManager {
         consentPreferencesStorage?.preferences = nil
         currentPolicy.preferences.resetConsentCategories()
         currentPolicy.preferences.setConsentStatus(.unknown)
-        trackUserConsentPreferences()
     }
 }

--- a/tealium/core/consentmanager/ConsentManagerModule.swift
+++ b/tealium/core/consentmanager/ConsentManagerModule.swift
@@ -121,7 +121,7 @@ class ConsentManagerModule: DispatchValidator {
 
 }
 
-fileprivate extension TealiumTrackRequest {
+extension TealiumTrackRequest {
     private static let auditEvents = [ConsentKey.consentPartialEventName,
                                       ConsentKey.consentGrantedEventName,
                                       ConsentKey.consentDeclinedEventName,

--- a/tealium/core/consentmanager/ConsentPolicies.swift
+++ b/tealium/core/consentmanager/ConsentPolicies.swift
@@ -121,14 +121,13 @@ public extension GDPRConsentPolicyCreatable {
     var shouldLogConsentStatus: Bool { true }
 
     var consentTrackingEventName: String {
-        if preferences.consentStatus == .notConsented {
+        guard preferences.consentStatus != .notConsented else {
             return ConsentKey.consentDeclinedEventName
         }
-        if let currentCategories = preferences.consentCategories?.count, currentCategories < TealiumConsentCategories.all.count {
+        guard let currentCategories = preferences.consentCategories, currentCategories.count >= TealiumConsentCategories.all.count else {
             return ConsentKey.consentPartialEventName
-        } else {
-            return ConsentKey.consentGrantedEventName
         }
+        return ConsentKey.consentGrantedEventName
     }
 
     var shouldUpdateConsentCookie: Bool { true }


### PR DESCRIPTION
Remove consent track event when resetting consent.
Avoid deleting audit events when deleting the queue.
Ensure decline_consent events are sent even if initially blocked (like from a DispatchValidator or Connectivity)