### PR TITLE
[MT-1787] Avoid keeping a reference of Tealium's enableCompletion

### DIFF
--- a/support/tests/test_tealium_core/PubSubTests.swift
+++ b/support/tests/test_tealium_core/PubSubTests.swift
@@ -345,25 +345,27 @@ class PubSubTests: XCTestCase {
 
 }
 
-
-class RetaiCycleHelper<P: TealiumPublisherProtocol> {
-    
-    
-    let anyPublisher: P
+class DeinitTester {
     var onDeinit: (() -> ())
+    init(onDeinit: @escaping () -> ()) {
+        self.onDeinit = onDeinit
+    }
+
+    deinit {
+        onDeinit()
+    }
+
+}
+
+class RetaiCycleHelper<P: TealiumPublisherProtocol>: DeinitTester {
+    let anyPublisher: P
     var subscription: TealiumSubscription<P.Element>?
     
     init(publisher: P, onDeinit: @escaping () -> ()) {
         self.anyPublisher = publisher
-        self.onDeinit = onDeinit
-        
+        super.init(onDeinit: onDeinit)
         self.subscription = publisher.asObservable().subscribe { elem in
             print(self)
         }
     }
-    
-    deinit {
-        onDeinit()
-    }
-    
 }

--- a/support/tests/test_tealium_core/TealiumExtensionTests.swift
+++ b/support/tests/test_tealium_core/TealiumExtensionTests.swift
@@ -369,4 +369,20 @@ class TealiumExtensionTests: XCTestCase {
         let queryItems = [URLQueryItem(name: "key1", value: "value1"), URLQueryItem(name: "key2", value: "value2")]
         XCTAssertTrue(URLComponents(url: url!.appendingQueryItems(queryItems), resolvingAgainstBaseURL: false)!.queryItems!.elementsEqual(queryItems))
     }
+
+    func test_after_completion_captured_objects_deallocate() {
+        let deinitCalled = expectation(description: "Deinit is called")
+        let config = testTealiumConfig.copy
+        var deinitHelper: DeinitTester? = DeinitTester {
+            deinitCalled.fulfill()
+        }
+        _ = Tealium(config: config) { [deinitHelper] _ in
+            _ = deinitHelper
+        }
+        deinitHelper = nil
+        waitOnTealiumSerialQueue {
+            waitForExpectations(timeout: 0.1)
+        }
+    }
+
 }

--- a/support/tests/test_tealium_core/TealiumInstanceManagerTests.swift
+++ b/support/tests/test_tealium_core/TealiumInstanceManagerTests.swift
@@ -63,5 +63,4 @@ class TealiumInstanceManagerTests: XCTestCase {
             XCTAssertEqual(url.absoluteString, dataLayerUrl)
         }
     }
-
 }

--- a/support/tests/test_tealium_tagmanagement/TagManagementModuleTests.swift
+++ b/support/tests/test_tealium_tagmanagement/TagManagementModuleTests.swift
@@ -46,27 +46,32 @@ class TagManagementModuleTests: XCTestCase {
         let track = TealiumTrackRequest(data: ["test": "track"])
         let batch = TealiumBatchTrackRequest(trackRequests: [track, track, track])
         let remote = TealiumRemoteAPIRequest(trackRequest: track)
-
-        module.enqueue(track, completion: nil)
-        XCTAssertEqual(module.pendingTrackRequests.count, 1)
-        if let request = module.pendingTrackRequests[0].0 as? TealiumTrackRequest {
-            XCTAssertEqual(request.trackDictionary["test"] as! String, "track")
+        TealiumQueues.backgroundSerialQueue.sync {
+            module.enqueue(track, completion: nil)
+            XCTAssertEqual(module.pendingTrackRequests.count, 1)
+            if let request = module.pendingTrackRequests[0].0 as? TealiumTrackRequest {
+                XCTAssertEqual(request.trackDictionary["test"] as! String, "track")
+            }
         }
+
 
         module = TagManagementModule(context: context, delegate: self, tagManagement: mockTagmanagement)
 
-        module.enqueue(batch, completion: nil)
-        XCTAssertEqual(module.pendingTrackRequests.count, 1)
-        if let request = module.pendingTrackRequests[0].0 as? TealiumTrackRequest {
-            XCTAssertEqual(request.trackDictionary["test"] as! String, "track")
+        TealiumQueues.backgroundSerialQueue.sync {
+            module.enqueue(batch, completion: nil)
+            XCTAssertEqual(module.pendingTrackRequests.count, 1)
+            if let request = module.pendingTrackRequests[0].0 as? TealiumTrackRequest {
+                XCTAssertEqual(request.trackDictionary["test"] as! String, "track")
+            }
         }
-
         module = TagManagementModule(context: context, delegate: self, tagManagement: mockTagmanagement)
 
-        module.enqueue(remote, completion: nil)
-        XCTAssertEqual(module.pendingTrackRequests.count, 1)
-        if let request = module.pendingTrackRequests[0].0 as? TealiumTrackRequest {
-            XCTAssertEqual(request.trackDictionary["test"] as! String, "track")
+        TealiumQueues.backgroundSerialQueue.sync {
+            module.enqueue(remote, completion: nil)
+            XCTAssertEqual(module.pendingTrackRequests.count, 1)
+            if let request = module.pendingTrackRequests[0].0 as? TealiumTrackRequest {
+                XCTAssertEqual(request.trackDictionary["test"] as! String, "track")
+            }
         }
     }
 

--- a/tealium/core/Tealium.swift
+++ b/tealium/core/Tealium.swift
@@ -10,7 +10,6 @@ import Foundation
 ///  Public interface for the Tealium library.
 public class Tealium {
 
-    var enableCompletion: ((_ result: Result<Bool, Error>) -> Void)?
     public static let lifecycleListeners = TealiumLifecycleListeners()
     public var dataLayer: DataLayerManagerProtocol
     // swiftlint:disable identifier_name
@@ -33,7 +32,6 @@ public class Tealium {
                 enableCompletion?(.success(true))
             }
         }
-        self.enableCompletion = enableCompletion
         self.dataLayer = dataLayer ?? DataLayer(config: config)
         self.migrator = migrator ?? Migrator(config: config)
         if config.shouldMigratePersistentData {

--- a/tealium/dispatchers/tagmanagement/TagManagementWKWebView.swift
+++ b/tealium/dispatchers/tagmanagement/TagManagementWKWebView.swift
@@ -74,7 +74,8 @@ class TagManagementWKWebView: NSObject, TagManagementProtocol, LoggingDataToStri
             setWebViewDelegates(delegates)
         }
         if let completion = completion {
-            enableCompletion = { success, error in
+            enableCompletion = { [weak self] success, error in
+                self?.enableCompletion = nil
                 TealiumQueues.backgroundSerialQueue.async {
                     completion(success, error)
                 }
@@ -276,11 +277,7 @@ class TagManagementWKWebView: NSObject, TagManagementProtocol, LoggingDataToStri
         let success = state == .loadSuccess
         self.currentState = success ? .isLoaded : .didFailToLoad
         let finalError = success ? nil : error
-
-        if let enableCompletion = enableCompletion {
-            self.enableCompletion = nil
-            enableCompletion(success, finalError)
-        }
+        enableCompletion?(success, finalError)
         if let reloadHandler = self.reloadHandler {
             self.reloadHandler = nil
             TealiumQueues.backgroundSerialQueue.async {


### PR DESCRIPTION
This was preventing cleanup of resources captured by that block.