### PR TITLE
[MT-1881] Avoid adding cache buster on remote commands URLs

### DIFF
--- a/support/tests/test_tealium_remotecommands/RemoteCommandExtensionsTests.swift
+++ b/support/tests/test_tealium_remotecommands/RemoteCommandExtensionsTests.swift
@@ -60,9 +60,16 @@ class RemoteCommandExtensionsTests: XCTestCase {
         XCTAssertFalse(anotherInvalidURLString.isValidUrl)
     }
 
+    @available(*, deprecated)
     func testCacheBuster() {
         let urlString = "https://www.tealium.com"
         XCTAssertTrue(urlString.cacheBuster.starts(with: "https://www.tealium.com?_cb="))
+    }
+
+    @available(*, deprecated)
+    func testCacheBusterWithQueryParameters() {
+        let urlString = "https://www.tealium.com?some=value"
+        XCTAssertTrue(urlString.cacheBuster.starts(with: "https://www.tealium.com?some=value&_cb="))
     }
 
     func testRemoteCommandsErrorLocalizedDescription() {

--- a/tealium-swift.podspec
+++ b/tealium-swift.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.name         = "tealium-swift"
   s.module_name  = "TealiumSwift"
-  s.version      = "2.18.1"
+  s.version      = "2.18.2"
   s.summary      = "Tealium Swift Integration Library"
 
   # This description is used to generate tags and improve search results.

--- a/tealium/core/TealiumConstants.swift
+++ b/tealium/core/TealiumConstants.swift
@@ -14,7 +14,7 @@ public enum Dispatchers {}
 
 public enum TealiumValue {
     public static let libraryName = "swift"
-    public static let libraryVersion = "2.18.1"
+    public static let libraryVersion = "2.18.2"
     // This is the current limit for performance reasons. May be increased in future
     public static let maxEventBatchSize = 10
     public static let defaultMinimumDiskSpace: Int32 = 20_000_000

--- a/tealium/core/dispatchmanager/DispatchManager.swift
+++ b/tealium/core/dispatchmanager/DispatchManager.swift
@@ -472,11 +472,11 @@ extension DispatchManager {
 // Logging
 extension DispatchManager {
 
-    func logModuleResponse (for module: String,
-                            request: TealiumRequest,
-                            info: [String: Any]?,
-                            success: Bool,
-                            error: Error?) {
+    func logModuleResponse(for module: String,
+                           request: TealiumRequest,
+                           info: [String: Any]?,
+                           success: Bool,
+                           error: Error?) {
         let message = success ? "Successful Track" : "Failed with error: \(error?.localizedDescription ?? "")"
         let logLevel: TealiumLogLevel = success ? .info : .error
         var uuid: String?

--- a/tealium/core/storage/TealiumDiskStorage.swift
+++ b/tealium/core/storage/TealiumDiskStorage.swift
@@ -95,7 +95,7 @@ public class TealiumDiskStorage: TealiumDiskStorageProtocol {
     /// Generates a file path for the data to be saved.
     ///
     /// - Parameter name: `String` containing
-    func filePath (_ name: String) -> String {
+    func filePath(_ name: String) -> String {
         return "\(filePath)\(name)"
     }
 

--- a/tealium/core/utils/Dictionary+Tealium.swift
+++ b/tealium/core/utils/Dictionary+Tealium.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Allows use of plus operator for array reduction calls.
-func + <Key, Value> (lhs: [Key: Value], rhs: [Key: Value]) -> [Key: Value] {
+func + <Key, Value>(lhs: [Key: Value], rhs: [Key: Value]) -> [Key: Value] {
     var result = lhs
     rhs.forEach { result[$0] = $1 }
     return result

--- a/tealium/dispatchers/remotecommands/RemoteCommandsExtensions.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommandsExtensions.swift
@@ -143,8 +143,11 @@ extension URLRequest {
 public extension String {
 
     /// Adds the key _cb= to the end of the url with a random number to clear the cached file from the CDN
+    @available(*, deprecated, message: "Do not use. This is going to be removed in a future release.")
     var cacheBuster: String {
-        return ("\(self)?_cb=\(Int.random(in: 1...10_000))")
+        URL(string: self)?.appendingQueryItems([
+            URLQueryItem(name: "_cb", value: "\(Int.random(in: 1...10_000))")
+        ]).absoluteString ?? self
     }
 }
 #endif

--- a/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
+++ b/tealium/dispatchers/remotecommands/RemoteCommandsManager.swift
@@ -97,7 +97,7 @@ public class RemoteCommandsManager: NSObject, RemoteCommandsManagerProtocol {
             }
         case .remote(let urlString):
             jsonCommands.append(remoteCommand)
-            guard let url = URL(string: urlString.cacheBuster) else {
+            guard let url = URL(string: urlString) else {
                 return
             }
             let parameters = RefreshParameters<RemoteCommandConfig>(id: remoteCommand.commandId,

--- a/tealium/dispatchers/tagmanagement/TagManagementProtocol.swift
+++ b/tealium/dispatchers/tagmanagement/TagManagementProtocol.swift
@@ -22,10 +22,10 @@ protocol TagManagementProtocol {
     ///     - delegates: `[AnyObject]?` Array of delegates, downcast from AnyObject to account for any future potential changes in WebView APIs
     ///     - view: `UIView? `- required `WKWebView`, if one is not provided we attach to the window object
     ///     - completion: completion block to be called when the webview has finished loading
-    func enable (webviewURL: URL?,
-                 delegates: [WKNavigationDelegate]?,
-                 view: UIView?,
-                 completion: ((Bool, Error?) -> Void)?)
+    func enable(webviewURL: URL?,
+                delegates: [WKNavigationDelegate]?,
+                view: UIView?,
+                completion: ((Bool, Error?) -> Void)?)
 
     /// Called when the module needs to disable the webview.
     func disable()
@@ -69,7 +69,7 @@ protocol TagManagementProtocol {
     /// - Parameters:
     ///     - jsString: `String` containing the JavaScript call to be executed in the webview
     ///     - completion: Optional completion block to be called after the JavaScript call completes
-    func evaluateJavascript (_ jsString: String, _ completion: (([String: Any]) -> Void)?)
+    func evaluateJavascript(_ jsString: String, _ completion: (([String: Any]) -> Void)?)
 
     /// Adds optional delegates to the WebView instance.
     /// ￼

--- a/tealium/dispatchers/tagmanagement/TagManagementWKWebView.swift
+++ b/tealium/dispatchers/tagmanagement/TagManagementWKWebView.swift
@@ -242,7 +242,7 @@ class TagManagementWKWebView: NSObject, TagManagementProtocol, LoggingDataToStri
     /// - Parameters:
     ///     - jsString: `String` containing the JavaScript call to be executed in the webview
     ///     - completion: Optional completion block to be called after the JavaScript call completes
-    func evaluateJavascript (_ jsString: String, _ completion: (([String: Any]) -> Void)?) {
+    func evaluateJavascript(_ jsString: String, _ completion: (([String: Any]) -> Void)?) {
         // webview js evaluation must be on main thread
         TealiumQueues.secureMainThreadExecution { [weak self] in
             guard let self = self else {


### PR DESCRIPTION
This is to implement the same behavior as Android.
The CDN is now using sensible TTLs (60 minutes) anyway, so the cache buster is less relevant. 

Also:
- fix the implementation of the `cacheBuster` computed property, in case someone else was using it (it's public). 
- deprecate it as we don't need it anymore for ourselves and will be removed in the future. 
- some indentation fixes to remove swiftlint warnings. 
- increase version to 2.18.2.